### PR TITLE
feat: implement Poincaré BatchNorm2D layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Quick Reference Commands
+
+```bash
+# Install
+uv sync --locked --dev
+
+# Run all tests (~1,660 tests)
+uv run pytest
+
+# Run a single test file
+uv run pytest tests/test_manifolds.py -v
+
+# Run a single test function
+uv run pytest tests/test_manifolds.py::test_dist -v
+
+# Run a fast subset (dim2 only)
+uv run pytest -k "dim2"
+
+# Lint and format
+uv run ruff check hyperbolix tests benchmarks
+uv run ruff format hyperbolix tests benchmarks
+
+# Type check
+uv run pyright hyperbolix
+
+# All pre-commit hooks
+uv run pre-commit run --all-files
+
+# Benchmarks
+uv run pytest benchmarks/ --benchmark-only
+
+# Docs
+uv run mkdocs serve
+uv run mkdocs build --strict
+```
+
+## Verification
+
+After making changes, run the test files that cover the affected code:
+```bash
+uv run pytest tests/<relevant_test_file>.py -x -v
+```
+For example: manifold changes → `test_manifolds.py`, optimizer changes → `test_optimizers.py`, FGG layer changes → `nn_layers/test_hyperboloid_fgg.py`. Use `-k "dim2"` to speed up parametrized tests during iteration.
+
+## Architecture
+
+**hyperbolix** is a pure JAX library for hyperbolic deep learning built on Flax NNX.
+
+### Core design: vmap-native, single-point manifold operations
+
+Manifold methods (`dist`, `expmap`, `logmap`, `proj`, `ptransp`) operate on **single points** `(dim,) -> scalar` or `(dim,) -> (dim,)`. Batching is always explicit via `jax.vmap`. NN layers handle batching internally in their `__call__`.
+
+### Module layout
+
+- **`manifolds/`** — Class-based manifold API: `Poincare`, `Hyperboloid`, `Euclidean`. Each is instantiated with a dtype (`Poincare(dtype=jnp.float64)`). Conforms to `Manifold` protocol in `protocol.py`. `_base.py` has shared `ManifoldBase`.
+- **`nn_layers/`** — Flax NNX layers (`nnx.Module`). Two families:
+  - *Poincare*: `HypLinearPoincare`, `HypLinearPoincarePP`, `HypConv2DPoincare`, `PoincareBatchNorm2D`, `HypRegressionPoincare` (Ganea et al. 2018, Shimizu et al. 2020, van Spengler et al. 2023)
+  - *Hyperboloid*: `FGGLinear`, `FGGConv2D`, `FGGLorentzMLR`, `HTCLinear`, `HypLinearHyperboloidPP`, `LorentzConv2D` (Klis et al. 2026, Shimizu et al. 2020), attention layers, positional encodings, normalization
+  - *Hybrid*: `HyperPPFeatureScaling` — Euclidean-space feature scaling applied before `expmap_0` in hybrid networks (RMSNorm + activation + dim scaling + optional learned rescaling)
+  - `hyperboloid_core.py` has foundational ops: `hrc()`, `htc()`, `build_spacelike_V()`, `lorentz_midpoint()`
+- **`optim/`** — Riemannian optimizers (`riemannian_sgd`, `riemannian_adam`). Uses `ManifoldParam` (subclass of `nnx.Param`) to tag hyperbolic parameters. `_riemannian_base.py` has shared `make_riemannian_optimizer()`.
+- **`distributions/`** — Wrapped normal (Poincare/Hyperboloid) and uniform Poincare sampling.
+- **`utils/`** — Numerically stable math (`atanh`, `acosh`, `smooth_clamp`) and helpers.
+
+### Key patterns
+
+- **Curvature `c`** is passed dynamically at call time (not stored on layers), enabling learnable curvature via `softplus(param)`.
+- **`version_idx`** selects distance/operation variants and must be **static** for JIT (use `functools.partial` or `static_argnums`).
+- **`ManifoldParam`** tags params for Riemannian optimization. The optimizer auto-detects these and applies Riemannian gradients + projection; all other `nnx.Param`s get standard Euclidean updates.
+- **Layers accept `manifold_module`** (a manifold class instance) — never raw functions.
+- **NN layer parameter naming** follows Flax NNX conventions: `kernel` (not `weight`), `bias`.
+
+### Weight initialization
+
+- FGG layers: default `lorentz_kaiming` init with `std = sqrt(1/in_features)` using **ambient** dimensions (not spatial). FGGLinear default `0.5*eye` with bias `0.5`
+- FHCNN/HTC layers: small uniform `U(-0.02, 0.02)`
+- HyperboloidPP layer: standard normal `std = 1.0` (Shimizu et al. 2020 reference init)
+- Poincare layers: scaled normal `std = (2 * in_dim * out_dim)^{-0.5}` (van Spengler et al. 2023)
+- Standard inits (He, Xavier) are too large for hyperbolic layers
+
+### Float precision
+
+- Float32 reliable for hyperbolic distances < 7; float64 needed for distances > 10
+- Conformal factor lambda grows exponentially near Poincare ball boundary
+- Tests parametrize both dtypes with tolerances: `atol=4e-3` (f32), `atol=1e-7` (f64)
+
+### Test structure
+
+- `tests/conftest.py`: global fixtures — `seed_jax` (enables float64), `rng`, `dtype`, `tolerance`, `manifold_and_c`, `uniform_points`
+- Tests parametrized across seeds (10-12), dtypes (f32/f64), dims (2,5,10,15), manifolds with random curvatures
+- CI runs 15 test suites in parallel via matrix strategy
+
+## Dimension naming convention
+
+All tensor variables use capital letter suffixes: `logits_BLV`, `hidden_BD`, `x_BI`. Define a dimension key at the top of each file.
+
+## Flax NNX API (v0.12.0+)
+
+- `nnx.Optimizer` requires `wrt=nnx.Param`
+- `optimizer.update()` takes `(model, grads)` not just `(grads)`
+- Lists of modules must use `nnx.List([...])` not plain Python `list`
+
+## Pre-commit hooks
+
+Ruff auto-formats on commit (e.g., `x ** 2` -> `x**2`). When editing files after creation, match the reformatted content. Unused imports are auto-removed — always add imports and their usage in the same edit.

--- a/docs/api-reference/nn-layers.md
+++ b/docs/api-reference/nn-layers.md
@@ -8,6 +8,7 @@ Hyperbolix provides 20+ neural network layer classes and 5 activation functions 
 
 - **Linear Layers**: Poincaré and Hyperboloid linear transformations, including FGG (Fast and Geometrically Grounded) layers
 - **Convolutional Layers**: HCat-based, HRC-based, and FGG hyperbolic convolutions
+- **Normalization**: Poincaré batch normalization (`PoincareBatchNorm2D`), HRC-wrapped norms, and FGG mean-only batch norm
 - **Hypformer Components**: HTC (Hyperbolic Transformation Component) and HRC (Hyperbolic Regularization Component) with curvature-change support
 - **FGG Components**: `FGGLinear`, `FGGConv2D`, `FGGMeanOnlyBatchNorm` from Klis et al. (2026) — linear-distance growth, ~3× faster than prior work
 - **Attention Layers**: Three hyperbolic attention variants (linear O(N), softmax O(N²), full Lorentzian O(N²)) from the Hypformer paper
@@ -179,6 +180,57 @@ x = jax.random.normal(jax.random.PRNGKey(1), (8, 28, 28, 16)) * 0.1
 # Forward pass — returns tangent-space output
 output = conv(x, c=1.0)
 print(output.shape)  # (8, 28, 28, 32)
+```
+
+### Poincaré Batch Normalization
+
+::: hyperbolix.nn_layers.PoincareBatchNorm2D
+    options:
+      show_source: true
+      heading_level: 4
+
+`PoincareBatchNorm2D` operates in tangent space (matching conv layer I/O), mapping to the manifold internally for geometric operations: Einstein midpoint, Fréchet variance, parallel transport, and variance rescaling. Use between Poincaré convolution layers following the reference ResNet pattern: `conv → bn → relu → conv → bn → skip`.
+
+::: hyperbolix.nn_layers.poincare_midpoint
+    options:
+      show_source: true
+      heading_level: 4
+
+::: hyperbolix.nn_layers.frechet_variance
+    options:
+      show_source: true
+      heading_level: 4
+
+#### Poincaré BatchNorm Example
+
+```python
+from hyperbolix.nn_layers import HypConv2DPoincare, PoincareBatchNorm2D
+from hyperbolix.manifolds import Poincare
+from flax import nnx
+import jax
+
+poincare = Poincare()
+
+# ResNet-style block: conv → bn → relu
+conv = HypConv2DPoincare(
+    manifold_module=poincare,
+    in_channels=16, out_channels=16,
+    kernel_size=3, rngs=nnx.Rngs(0),
+)
+bn = PoincareBatchNorm2D(poincare, num_features=16)
+
+# Input: tangent-space features (B, H, W, C)
+x = jax.random.normal(jax.random.PRNGKey(0), (4, 8, 8, 16)) * 0.1
+
+# Training: use_running_average=False (default)
+h = conv(x, c=0.1)
+h = bn(h, c=0.1)
+h = jax.nn.relu(h)
+
+# Evaluation: use_running_average=True
+h_eval = conv(x, c=0.1)
+h_eval = bn(h_eval, c=0.1, use_running_average=True)
+h_eval = jax.nn.relu(h_eval)
 ```
 
 ### FGGConv2D (Klis et al. 2026)

--- a/hyperbolix/nn_layers/__init__.py
+++ b/hyperbolix/nn_layers/__init__.py
@@ -26,6 +26,7 @@ from .hyperboloid_positional import HyperbolicRoPE, HypformerPositionalEncoding,
 from .hyperboloid_regression import FGGLorentzMLR, HypRegressionHyperboloid
 from .hyperboloid_regularization import FGGMeanOnlyBatchNorm, HRCBatchNorm, HRCDropout, HRCLayerNorm, HRCRMSNorm
 from .poincare_activations import poincare_leaky_relu, poincare_relu, poincare_tanh
+from .poincare_batchnorm import PoincareBatchNorm2D, frechet_variance, poincare_midpoint
 from .poincare_conv import HypConv2DPoincare
 from .poincare_linear import HypLinearPoincare, HypLinearPoincarePP
 from .poincare_regression import HypRegressionPoincare, HypRegressionPoincarePP
@@ -57,8 +58,10 @@ __all__ = [
     "HyperbolicSoftmaxAttention",
     "HypformerPositionalEncoding",
     "LorentzConv2D",
+    "PoincareBatchNorm2D",
     "build_spacelike_V",
     "focus_transform",
+    "frechet_variance",
     "hope",
     "hrc",
     "hrc_gelu",
@@ -75,6 +78,7 @@ __all__ = [
     "lorentz_midpoint",
     "lorentz_residual",
     "poincare_leaky_relu",
+    "poincare_midpoint",
     "poincare_relu",
     "poincare_tanh",
     "spatial_to_hyperboloid",

--- a/hyperbolix/nn_layers/poincare_batchnorm.py
+++ b/hyperbolix/nn_layers/poincare_batchnorm.py
@@ -1,0 +1,242 @@
+"""Poincaré batch normalization for JAX/Flax NNX.
+
+Implements PoincareBatchNorm2D following the Poincaré ResNet
+(van Spengler et al. 2023). The layer operates in tangent space
+(matching conv layer I/O), mapping to the manifold internally
+for geometric operations.
+
+Algorithm:
+    1. expmap_0(x) — tangent input → manifold
+    2. expmap_0(self.mean) — learned mean → manifold
+    3. Compute Einstein midpoint and Fréchet variance on manifold
+    4. logmap(x, batch_midpoint) — log-map all points at midpoint
+    5. ptransp(v, batch_midpoint, learned_mean) — parallel transport
+    6. Rescale by sqrt(learned_var / (batch_var + eps))
+    7. expmap(v, learned_mean) — map back to manifold at learned mean
+    8. logmap_0(output) — manifold → tangent output
+
+Dimension key:
+  B: batch size
+  H: height          W: width
+  C: channels        N: flattened batch+spatial (B*H*W)
+"""
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jaxtyping import Array, Float
+
+from hyperbolix.manifolds.poincare import Poincare
+
+from ._helpers import validate_poincare_manifold
+
+
+def poincare_midpoint(
+    x_NC: Float[Array, "N C"],
+    manifold: Poincare,
+    c: float,
+    eps: float = 1e-6,
+) -> Float[Array, "C"]:
+    """Compute Einstein midpoint of Poincaré ball points.
+
+    Uses conformal factor weighting: midpoint = Σ(λ²·x) / Σ(λ²),
+    then projects onto the ball.
+
+    Parameters
+    ----------
+    x_NC : Array, shape (N, C)
+        Points on the Poincaré ball.
+    manifold : Poincare
+        Poincaré manifold instance.
+    c : float
+        Curvature (positive).
+    eps : float
+        Numerical stability floor (default: 1e-6).
+
+    Returns
+    -------
+    Array, shape (C,)
+        Einstein midpoint on the Poincaré ball.
+    """
+    # lambda_N1: (N, 1) — conformal factor for each point
+    lambda_N1 = manifold.conformal_factor(x_NC, c)  # (N, 1)
+    lambda_sq_N1 = lambda_N1**2  # (N, 1)
+
+    # Weighted sum: Σ(λ²·x) / Σ(λ²)
+    numerator_C = jnp.sum(lambda_sq_N1 * x_NC, axis=0)  # (C,)
+    denominator = jnp.sum(lambda_sq_N1, axis=0) + eps  # (1,)
+
+    midpoint_C = numerator_C / denominator  # (C,)
+    return manifold.proj(midpoint_C, c)
+
+
+def frechet_variance(
+    x_NC: Float[Array, "N C"],
+    mean_C: Float[Array, "C"],
+    manifold: Poincare,
+    c: float,
+) -> Float[Array, ""]:
+    """Compute Fréchet variance: mean squared geodesic distance to mean.
+
+    Parameters
+    ----------
+    x_NC : Array, shape (N, C)
+        Points on the Poincaré ball.
+    mean_C : Array, shape (C,)
+        Mean point on the Poincaré ball.
+    manifold : Poincare
+        Poincaré manifold instance.
+    c : float
+        Curvature (positive).
+
+    Returns
+    -------
+    Array, scalar
+        Mean of squared geodesic distances.
+    """
+    # dist per point: (N,)
+    dists_N = jax.vmap(manifold.dist, in_axes=(0, None, None))(x_NC, mean_C, c)
+    return jnp.mean(dists_N**2)
+
+
+class PoincareBatchNorm2D(nnx.Module):
+    """Poincaré batch normalization for 2D feature maps.
+
+    Operates in tangent space (matching conv layer I/O). Internally maps
+    to the manifold for geometric operations (midpoint, parallel transport,
+    variance rescaling), then maps back to tangent space.
+
+    Follows ``nnx.BatchNorm`` interface: ``use_running_average`` is a
+    constructor parameter overridable at call time.
+
+    Parameters
+    ----------
+    manifold_module : Poincare
+        Poincaré manifold instance.
+    num_features : int
+        Number of channels (Poincaré ball dimension per pixel).
+    use_running_average : bool
+        If True, use running statistics instead of batch statistics
+        (default: False). Overridable at call time.
+    momentum : float
+        EMA momentum for running statistics (default: 0.9).
+    eps : float
+        Numerical stability floor (default: 1e-6).
+
+    References
+    ----------
+    van Spengler et al. "Poincaré ResNet." ICML 2023.
+    """
+
+    def __init__(
+        self,
+        manifold_module: Poincare,
+        num_features: int,
+        *,
+        use_running_average: bool = False,
+        momentum: float = 0.9,
+        eps: float = 1e-6,
+    ):
+        validate_poincare_manifold(
+            manifold_module,
+            required_methods=("expmap_0", "logmap_0", "logmap", "expmap", "ptransp", "proj", "dist", "conformal_factor"),
+        )
+        self.manifold = manifold_module
+        self.num_features = num_features
+        self.use_running_average = use_running_average
+        self.momentum = momentum
+        self.eps = eps
+
+        # Learnable parameters (tangent space)
+        self.mean = nnx.Param(jnp.zeros((num_features,)))  # learned mean
+        self.var = nnx.Param(jnp.ones(()))  # learned variance (scalar)
+
+        # Running statistics (tangent space)
+        self.running_mean = nnx.BatchStat(jnp.zeros((num_features,)))
+        self.running_var = nnx.BatchStat(jnp.ones(()))
+
+    def __call__(
+        self,
+        x_BHWC: Float[Array, "B H W C"],
+        c: float = 1.0,
+        use_running_average: bool | None = None,
+    ) -> Float[Array, "B H W C"]:
+        """Apply Poincaré batch normalization.
+
+        Parameters
+        ----------
+        x_BHWC : Array, shape (B, H, W, C)
+            Tangent-space input features.
+        c : float
+            Curvature (positive, default: 1.0).
+        use_running_average : bool or None
+            Override constructor setting. None uses constructor value.
+
+        Returns
+        -------
+        Array, shape (B, H, W, C)
+            Normalized tangent-space output.
+        """
+        # Resolve use_running_average: call-time > constructor
+        if use_running_average is None:
+            use_running_average = self.use_running_average
+
+        B, H, W, C = x_BHWC.shape
+
+        # Flatten (B, H, W, C) → (N, C)
+        x_NC = x_BHWC.reshape(-1, C)  # (N, C)
+
+        # --- Map to manifold ---
+        # x_NC are tangent vectors; map to Poincaré ball
+        x_manifold_NC = jax.vmap(self.manifold.expmap_0, in_axes=(0, None))(x_NC, c)  # (N, C)
+
+        if use_running_average:
+            # Use running stats (eval mode)
+            batch_mean_tangent_C = self.running_mean[...]  # (C,)
+            batch_var = self.running_var[...]  # scalar
+        else:
+            # Compute batch stats on manifold
+            batch_midpoint_C = poincare_midpoint(x_manifold_NC, self.manifold, c, self.eps)  # (C,)
+            batch_var = frechet_variance(x_manifold_NC, batch_midpoint_C, self.manifold, c)  # scalar
+
+            # Map midpoint back to tangent space for running stat storage
+            batch_mean_tangent_C = self.manifold.logmap_0(batch_midpoint_C, c)  # (C,)
+
+            # Update running statistics (EMA, no gradient flow)
+            self.running_mean[...] = jax.lax.stop_gradient(
+                self.momentum * self.running_mean[...] + (1.0 - self.momentum) * batch_mean_tangent_C
+            )
+            self.running_var[...] = jax.lax.stop_gradient(
+                self.momentum * self.running_var[...] + (1.0 - self.momentum) * batch_var
+            )
+
+        # Get the manifold-space mean to use for geometric operations
+        # (either from batch or from running stats)
+        if use_running_average:
+            input_mean_C = self.manifold.expmap_0(batch_mean_tangent_C, c)  # (C,)
+            current_var = batch_var
+        else:
+            input_mean_C = batch_midpoint_C  # already computed above  # (C,)
+            current_var = batch_var
+
+        # Learned mean on manifold
+        learned_mean_C = self.manifold.expmap_0(self.mean[...], c)  # (C,)
+
+        # --- Step 4: logmap all points at input mean ---
+        v_NC = jax.vmap(self.manifold.logmap, in_axes=(0, None, None))(x_manifold_NC, input_mean_C, c)  # (N, C)
+
+        # --- Step 5: parallel transport from input mean to learned mean ---
+        v_NC = jax.vmap(self.manifold.ptransp, in_axes=(0, None, None, None))(v_NC, input_mean_C, learned_mean_C, c)  # (N, C)
+
+        # --- Step 6: rescale by sqrt(learned_var / (batch_var + eps)) ---
+        scale = jnp.sqrt(self.var[...] / (current_var + self.eps))  # scalar
+        v_NC = v_NC * scale  # (N, C)
+
+        # --- Step 7: expmap at learned mean ---
+        out_NC = jax.vmap(self.manifold.expmap, in_axes=(0, None, None))(v_NC, learned_mean_C, c)  # (N, C)
+
+        # --- Step 8: logmap_0 back to tangent space ---
+        out_NC = jax.vmap(self.manifold.logmap_0, in_axes=(0, None))(out_NC, c)  # (N, C)
+
+        # Reshape back to (B, H, W, C)
+        return out_NC.reshape(B, H, W, C)

--- a/tests/nn_layers/test_poincare_batchnorm.py
+++ b/tests/nn_layers/test_poincare_batchnorm.py
@@ -1,0 +1,330 @@
+"""Tests for Poincaré batch normalization layer and helpers.
+
+Dimension key:
+  B: batch size     H: height     W: width
+  C: channels       N: flattened (B*H*W)
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from hyperbolix.manifolds import Poincare
+from hyperbolix.nn_layers.poincare_batchnorm import (
+    PoincareBatchNorm2D,
+    frechet_variance,
+    poincare_midpoint,
+)
+
+# ============================================================================
+# Helper: create random tangent/manifold inputs
+# ============================================================================
+
+
+def _make_poincare_points(key, shape, c, dtype):
+    """Create random points on the Poincaré ball via expmap_0 of small tangent vectors."""
+    manifold = Poincare(dtype=dtype)
+    tangent = jax.random.normal(key, shape, dtype=dtype) * 0.1
+    if tangent.ndim == 1:
+        return manifold.expmap_0(tangent, c)
+    return jax.vmap(manifold.expmap_0, in_axes=(0, None))(tangent, c)
+
+
+def _make_tangent_input(key, shape, dtype):
+    """Create random tangent-space input (small vectors near origin)."""
+    return jax.random.normal(key, shape, dtype=dtype) * 0.1
+
+
+# ============================================================================
+# Midpoint Tests
+# ============================================================================
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_midpoint_on_manifold(dtype):
+    """Midpoint lies on the Poincaré ball."""
+    key = jax.random.PRNGKey(42)
+    c = 1.0
+    manifold = Poincare(dtype=dtype)
+    x_NC = _make_poincare_points(key, (16, 8), c, dtype)
+
+    mid_C = poincare_midpoint(x_NC, manifold, c)
+
+    assert mid_C.shape == (8,)
+    assert manifold.is_in_manifold(mid_C, c, atol=1e-4)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_midpoint_identical_points(dtype):
+    """Midpoint of N copies of the same point equals that point."""
+    key = jax.random.PRNGKey(0)
+    c = 1.0
+    manifold = Poincare(dtype=dtype)
+    single = _make_poincare_points(key, (4,), c, dtype)  # (C,)
+    repeated_NC = jnp.tile(single, (10, 1))  # (10, C)
+
+    mid_C = poincare_midpoint(repeated_NC, manifold, c)
+
+    atol = 1e-3 if dtype == jnp.float32 else 1e-7
+    assert jnp.allclose(mid_C, single, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_midpoint_gradients(dtype):
+    """Gradients through midpoint are finite."""
+    key = jax.random.PRNGKey(1)
+    c = 1.0
+    manifold = Poincare(dtype=dtype)
+    x_NC = _make_poincare_points(key, (8, 4), c, dtype)
+
+    def loss_fn(x):
+        mid = poincare_midpoint(x, manifold, c)
+        return jnp.sum(mid**2)
+
+    grads = jax.grad(loss_fn)(x_NC)
+    assert jnp.all(jnp.isfinite(grads))
+
+
+# ============================================================================
+# Variance Tests
+# ============================================================================
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_frechet_variance_nonnegative(dtype):
+    """Fréchet variance is non-negative."""
+    key = jax.random.PRNGKey(42)
+    c = 1.0
+    manifold = Poincare(dtype=dtype)
+    x_NC = _make_poincare_points(key, (16, 8), c, dtype)
+    mean_C = poincare_midpoint(x_NC, manifold, c)
+
+    var = frechet_variance(x_NC, mean_C, manifold, c)
+    assert var >= 0.0
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_frechet_variance_identical_points(dtype):
+    """Variance of identical points is zero."""
+    key = jax.random.PRNGKey(0)
+    c = 1.0
+    manifold = Poincare(dtype=dtype)
+    single = _make_poincare_points(key, (4,), c, dtype)
+    repeated_NC = jnp.tile(single, (10, 1))
+
+    var = frechet_variance(repeated_NC, single, manifold, c)
+    assert var < 1e-6
+
+
+# ============================================================================
+# BatchNorm Tests
+# ============================================================================
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_bn_output_shape(dtype):
+    """Output shape matches input shape (B, H, W, C)."""
+    manifold = Poincare(dtype=dtype)
+    bn = PoincareBatchNorm2D(manifold, num_features=8)
+    key = jax.random.PRNGKey(42)
+    x_BHWC = _make_tangent_input(key, (2, 4, 4, 8), dtype)
+
+    out = bn(x_BHWC, c=1.0)
+    assert out.shape == (2, 4, 4, 8)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_bn_output_finite(dtype):
+    """No NaN or Inf in output."""
+    manifold = Poincare(dtype=dtype)
+    bn = PoincareBatchNorm2D(manifold, num_features=8)
+    key = jax.random.PRNGKey(42)
+    x_BHWC = _make_tangent_input(key, (2, 4, 4, 8), dtype)
+
+    out = bn(x_BHWC, c=1.0)
+    assert jnp.all(jnp.isfinite(out))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_bn_output_mappable_to_manifold(dtype):
+    """Tangent output maps to valid manifold points via expmap_0."""
+    manifold = Poincare(dtype=dtype)
+    bn = PoincareBatchNorm2D(manifold, num_features=4)
+    key = jax.random.PRNGKey(42)
+    x_BHWC = _make_tangent_input(key, (2, 3, 3, 4), dtype)
+
+    out_BHWC = bn(x_BHWC, c=1.0)
+    # Flatten and map to manifold
+    out_NC = out_BHWC.reshape(-1, 4)
+    on_manifold_NC = jax.vmap(manifold.expmap_0, in_axes=(0, None))(out_NC, 1.0)
+
+    # All points should be on the manifold
+    checks = jax.vmap(manifold.is_in_manifold, in_axes=(0, None))(on_manifold_NC, 1.0)
+    assert jnp.all(checks)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_bn_gradient(dtype):
+    """Finite gradients for mean and var params."""
+    manifold = Poincare(dtype=dtype)
+    bn = PoincareBatchNorm2D(manifold, num_features=4)
+    key = jax.random.PRNGKey(42)
+    x_BHWC = _make_tangent_input(key, (2, 3, 3, 4), dtype)
+
+    def loss_fn(bn):
+        out = bn(x_BHWC, c=1.0)
+        return jnp.sum(out**2)
+
+    loss, grads = nnx.value_and_grad(loss_fn)(bn)
+    assert jnp.isfinite(loss)
+
+    # Check mean and var gradients are finite
+    mean_grad = grads.mean[...]
+    var_grad = grads.var[...]
+    assert jnp.all(jnp.isfinite(mean_grad)), f"mean grad not finite: {mean_grad}"
+    assert jnp.all(jnp.isfinite(var_grad)), f"var grad not finite: {var_grad}"
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_bn_jitted(dtype):
+    """Works under @nnx.jit."""
+    manifold = Poincare(dtype=dtype)
+    bn = PoincareBatchNorm2D(manifold, num_features=4)
+    key = jax.random.PRNGKey(42)
+    x_BHWC = _make_tangent_input(key, (2, 3, 3, 4), dtype)
+
+    @nnx.jit
+    def forward(bn, x):
+        return bn(x, c=1.0)
+
+    out = forward(bn, x_BHWC)
+    assert out.shape == x_BHWC.shape
+    assert jnp.all(jnp.isfinite(out))
+
+
+@pytest.mark.parametrize("c", [0.5, 1.0, 2.0])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_bn_different_curvatures(c, dtype):
+    """Works with different curvature values."""
+    manifold = Poincare(dtype=dtype)
+    bn = PoincareBatchNorm2D(manifold, num_features=4)
+    key = jax.random.PRNGKey(42)
+    # Smaller tangent vectors for higher curvature (smaller ball)
+    scale = 0.05 / jnp.sqrt(c)
+    x_BHWC = jax.random.normal(key, (2, 3, 3, 4), dtype=dtype) * scale
+
+    out = bn(x_BHWC, c=c)
+    assert out.shape == x_BHWC.shape
+    assert jnp.all(jnp.isfinite(out))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_bn_running_stats_update(dtype):
+    """Running stats change during training, stay fixed during eval."""
+    manifold = Poincare(dtype=dtype)
+    bn = PoincareBatchNorm2D(manifold, num_features=4)
+    key = jax.random.PRNGKey(42)
+    x_BHWC = _make_tangent_input(key, (2, 3, 3, 4), dtype)
+
+    # Save initial running stats
+    init_running_mean = bn.running_mean[...].copy()
+    init_running_var = bn.running_var[...].copy()
+
+    # Training forward pass — should update running stats
+    _ = bn(x_BHWC, c=1.0, use_running_average=False)
+
+    assert not jnp.allclose(bn.running_mean[...], init_running_mean), "Running mean should have changed after training step"
+    assert not jnp.allclose(bn.running_var[...], init_running_var), "Running var should have changed after training step"
+
+    # Save updated running stats
+    updated_running_mean = bn.running_mean[...].copy()
+    updated_running_var = bn.running_var[...].copy()
+
+    # Eval forward pass — should NOT update running stats
+    _ = bn(x_BHWC, c=1.0, use_running_average=True)
+
+    assert jnp.array_equal(bn.running_mean[...], updated_running_mean)
+    assert jnp.array_equal(bn.running_var[...], updated_running_var)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_bn_train_vs_eval(dtype):
+    """Different outputs in train vs eval mode."""
+    manifold = Poincare(dtype=dtype)
+    bn = PoincareBatchNorm2D(manifold, num_features=4)
+    key = jax.random.PRNGKey(42)
+    x_BHWC = _make_tangent_input(key, (2, 3, 3, 4), dtype)
+
+    # Run a few training steps to update running stats
+    for i in range(3):
+        k = jax.random.PRNGKey(i + 10)
+        x = _make_tangent_input(k, (2, 3, 3, 4), dtype)
+        _ = bn(x, c=1.0, use_running_average=False)
+
+    # Compare train vs eval output on same input
+    out_train = bn(x_BHWC, c=1.0, use_running_average=False)
+    out_eval = bn(x_BHWC, c=1.0, use_running_average=True)
+
+    assert not jnp.allclose(out_train, out_eval), "Train and eval outputs should differ"
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_poincare_bn_chained_with_conv(dtype):
+    """conv → bn → relu → conv → bn → relu chain produces finite output and gradients."""
+    from hyperbolix.nn_layers.poincare_conv import HypConv2DPoincare
+
+    manifold = Poincare(dtype=dtype)
+    c = 0.5
+
+    conv1 = HypConv2DPoincare(
+        manifold,
+        in_channels=4,
+        out_channels=4,
+        kernel_size=3,
+        rngs=nnx.Rngs(0),
+        padding="SAME",
+        input_space="tangent",
+    )
+    bn1 = PoincareBatchNorm2D(manifold, num_features=4)
+
+    conv2 = HypConv2DPoincare(
+        manifold,
+        in_channels=4,
+        out_channels=4,
+        kernel_size=3,
+        rngs=nnx.Rngs(1),
+        padding="SAME",
+        input_space="tangent",
+    )
+    bn2 = PoincareBatchNorm2D(manifold, num_features=4)
+
+    key = jax.random.PRNGKey(42)
+    x_BHWC = _make_tangent_input(key, (2, 4, 4, 4), dtype)
+
+    def forward(conv1, bn1, conv2, bn2, x):
+        h = conv1(x, c=c)  # tangent → tangent
+        h = bn1(h, c=c)  # tangent → tangent
+        h = jax.nn.relu(h)  # tangent activation
+        h = conv2(h, c=c)  # tangent → tangent
+        h = bn2(h, c=c)  # tangent → tangent
+        h = jax.nn.relu(h)  # tangent activation
+        return h
+
+    out = forward(conv1, bn1, conv2, bn2, x_BHWC)
+    assert out.shape == x_BHWC.shape
+    assert jnp.all(jnp.isfinite(out)), "Output has non-finite values"
+
+    # Check gradients through the full chain
+    def loss_fn(conv1, bn1, conv2, bn2):
+        out = forward(conv1, bn1, conv2, bn2, x_BHWC)
+        return jnp.sum(out**2)
+
+    loss, grads = nnx.value_and_grad(loss_fn, argnums=(0, 1, 2, 3))(conv1, bn1, conv2, bn2)
+    assert jnp.isfinite(loss), f"Loss is not finite: {loss}"
+
+    # Check bn gradient params are finite
+    bn1_mean_grad = grads[1].mean[...]
+    bn1_var_grad = grads[1].var[...]
+    assert jnp.all(jnp.isfinite(bn1_mean_grad)), "bn1 mean grad not finite"
+    assert jnp.all(jnp.isfinite(bn1_var_grad)), "bn1 var grad not finite"


### PR DESCRIPTION
## Summary

- Implements `PoincareBatchNorm2D` following van Spengler et al. 2023 reference
- Helper functions: `poincare_midpoint` and `frechet_variance` for manifold-space statistics
- Geometric normalization: tangent I/O with manifold-space operations (Einstein midpoint, Fréchet variance, parallel transport)
- Running statistics with EMA for eval mode, matching `nnx.BatchNorm` interface

## Test Plan

✅ 32 tests all passing:
- Midpoint validity and gradient flow
- Variance non-negativity and identical-point behavior
- BatchNorm shape preservation, finite output, manifold-mappable output
- Finite gradients for learnable params
- JIT compatibility
- Different curvatures (0.5, 1.0, 2.0)
- Running stats update behavior
- Train vs eval mode differences
- Conv→BN→ReLU→Conv→BN→ReLU chaining with finite output and gradients
- Float32 and float64 precision
✅ 0 type errors (pyright)
✅ 0 lint errors (ruff, isort)
✅ No regressions: 48/48 conv tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)