### PR TITLE
feat: implement FHNN layers for Hyperboloid manifold

### DIFF
--- a/docs/api-reference/nn-layers.md
+++ b/docs/api-reference/nn-layers.md
@@ -40,6 +40,11 @@ All layers follow Flax NNX conventions and store manifold module references.
       show_source: true
       heading_level: 4
 
+::: hyperbolix.nn_layers.HypLinearHyperboloidFHNN
+    options:
+      show_source: true
+      heading_level: 4
+
 ::: hyperbolix.nn_layers.HypLinearHyperboloidPP
     options:
       show_source: true
@@ -83,6 +88,11 @@ print(output.shape)  # (10, 16)
 ### Hyperboloid Convolutions
 
 ::: hyperbolix.nn_layers.HypConv2DHyperboloid
+    options:
+      show_source: true
+      heading_level: 4
+
+::: hyperbolix.nn_layers.HypConv2DHyperboloidFHNN
     options:
       show_source: true
       heading_level: 4

--- a/hyperbolix/nn_layers/__init__.py
+++ b/hyperbolix/nn_layers/__init__.py
@@ -19,9 +19,15 @@ from .hyperboloid_attention import (
     HyperbolicSoftmaxAttention,
     focus_transform,
 )
-from .hyperboloid_conv import FGGConv2D, HypConv2DHyperboloid, HypConv2DHyperboloidPP, LorentzConv2D
+from .hyperboloid_conv import FGGConv2D, HypConv2DHyperboloid, HypConv2DHyperboloidFHNN, HypConv2DHyperboloidPP, LorentzConv2D
 from .hyperboloid_core import build_spacelike_V, hrc, htc, lorentz_midpoint, lorentz_residual, spatial_to_hyperboloid
-from .hyperboloid_linear import FGGLinear, HTCLinear, HypLinearHyperboloidFHCNN, HypLinearHyperboloidPP
+from .hyperboloid_linear import (
+    FGGLinear,
+    HTCLinear,
+    HypLinearHyperboloidFHCNN,
+    HypLinearHyperboloidFHNN,
+    HypLinearHyperboloidPP,
+)
 from .hyperboloid_positional import HyperbolicRoPE, HypformerPositionalEncoding, hope
 from .hyperboloid_regression import FGGLorentzMLR, HypRegressionHyperboloid
 from .hyperboloid_regularization import FGGMeanOnlyBatchNorm, HRCBatchNorm, HRCDropout, HRCLayerNorm, HRCRMSNorm
@@ -42,9 +48,11 @@ __all__ = [
     "HRCRMSNorm",
     "HTCLinear",
     "HypConv2DHyperboloid",
+    "HypConv2DHyperboloidFHNN",
     "HypConv2DHyperboloidPP",
     "HypConv2DPoincare",
     "HypLinearHyperboloidFHCNN",
+    "HypLinearHyperboloidFHNN",
     "HypLinearHyperboloidPP",
     "HypLinearPoincare",
     "HypLinearPoincarePP",

--- a/hyperbolix/nn_layers/hyperboloid_conv.py
+++ b/hyperbolix/nn_layers/hyperboloid_conv.py
@@ -18,7 +18,13 @@ from hyperbolix.manifolds.hyperboloid import Hyperboloid
 
 from ._helpers import validate_hyperboloid_manifold
 from .hyperboloid_core import hrc
-from .hyperboloid_linear import _fgg_linear_forward, _fhcnn_forward, _get_effective_kernel, _hyperboloid_pp_forward
+from .hyperboloid_linear import (
+    _fgg_linear_forward,
+    _fhcnn_forward,
+    _fhnn_forward,
+    _get_effective_kernel,
+    _hyperboloid_pp_forward,
+)
 
 
 class LorentzConv2D(nnx.Module):
@@ -335,6 +341,229 @@ class HypConv2DHyperboloid(nnx.Module):
         output_BHWC = linear_out_NC.reshape(batch, out_h, out_w, self.out_channels)
 
         return output_BHWC
+
+
+class HypConv2DHyperboloidFHNN(nnx.Module):
+    """Fully Hyperbolic Neural Networks 2D convolutional layer (Chen et al. 2021).
+
+    Uses HCat (Lorentz direct concatenation) to combine receptive field points,
+    then applies the FHNN linear transform (time-primary sigmoid parameterization)
+    for channel mixing.
+
+    Computation steps:
+        1) Map input to manifold via expmap_0 if input_space="tangent"
+        2) Extract receptive field (kernel_size x kernel_size) of hyperbolic points
+        3) Apply HCat (Lorentz direct concatenation) to combine receptive field points
+        4) Pass through FHNN linear (sigmoid time + spatial rescaling)
+
+    Parameters
+    ----------
+    manifold_module : Hyperboloid
+        Class-based Hyperboloid manifold instance
+    in_channels : int
+        Number of input channels (ambient dimension, including time component)
+    out_channels : int
+        Number of output channels (ambient dimension, including time component)
+    kernel_size : int or tuple[int, int]
+        Size of the convolutional kernel
+    rngs : nnx.Rngs
+        Random number generators for parameter initialization
+    stride : int or tuple[int, int]
+        Stride of the convolution (default: 1)
+    padding : str
+        Padding mode, either 'SAME' or 'VALID' (default: 'SAME')
+    input_space : str
+        Type of the input tensor, either 'tangent' or 'manifold' (default: 'manifold').
+        Note: This is a static configuration - changing it after initialization requires recompilation.
+    init_scale : float
+        Initial value for the learnable sigmoid scale (default: 2.3)
+    eps : float
+        Numerical stability epsilon (default: 1e-5)
+    activation : callable or None
+        Activation function to apply before the linear transformation (default: None).
+    dropout_rate : float or None
+        Dropout rate applied before the linear transformation (default: None).
+
+    Notes
+    -----
+    JIT Compatibility:
+        This layer is designed to work with nnx.jit. Configuration parameters (padding, input_space,
+        activation) are treated as static and baked into the compiled function.
+
+    See Also
+    --------
+    HypConv2DHyperboloid : Equivalent convolution using FHCNN linear instead of FHNN.
+    HypLinearHyperboloidFHNN : The underlying FHNN linear layer.
+
+    References
+    ----------
+    Weize Chen, et al. "Fully hyperbolic neural networks."
+        arXiv preprint arXiv:2105.14686 (2021).
+    """
+
+    def __init__(
+        self,
+        manifold_module: Hyperboloid,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int | tuple[int, int],
+        *,
+        rngs: nnx.Rngs,
+        stride: int | tuple[int, int] = 1,
+        padding: str = "SAME",
+        input_space: str = "manifold",
+        init_scale: float = 2.3,
+        eps: float = 1e-5,
+        activation: Callable[[Array], Array] | None = None,
+        dropout_rate: float | None = None,
+    ):
+        if padding not in ["SAME", "VALID"]:
+            raise ValueError(f"padding must be either 'SAME' or 'VALID', got '{padding}'")
+        if input_space not in ["tangent", "manifold"]:
+            raise ValueError(f"input_space must be either 'tangent' or 'manifold', got '{input_space}'")
+
+        # Static configuration
+        validate_hyperboloid_manifold(manifold_module, required_methods=("expmap_0", "hcat"))
+        self.manifold = manifold_module
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.input_space = input_space
+        self.padding = padding
+        self.eps = eps
+        self.activation = activation
+
+        if isinstance(kernel_size, int):
+            self.kernel_size = (kernel_size, kernel_size)
+        else:
+            self.kernel_size = kernel_size
+
+        if isinstance(stride, int):
+            self.stride = (stride, stride)
+        else:
+            self.stride = stride
+
+        # HCat output ambient dim: (in_channels - 1) * kh * kw + 1
+        kernel_h, kernel_w = self.kernel_size
+        N = kernel_h * kernel_w
+        d = in_channels - 1
+        hcat_out_ambient_dim = d * N + 1
+
+        # FHNN weight init: U(-0.02, 0.02) with time column zeroed (tangent vectors at origin)
+        bound = 0.02
+        weight_init = jax.random.uniform(rngs.params(), (out_channels, hcat_out_ambient_dim), minval=-bound, maxval=bound)
+        weight_init = weight_init.at[:, 0].set(0.0)
+        self.kernel = nnx.Param(weight_init)
+        self.bias = nnx.Param(jnp.zeros((1, out_channels)))
+
+        # Learnable scale for the sigmoid (always learnable in FHNN)
+        self.scale = nnx.Param(jnp.array(init_scale))
+
+        # Optional dropout
+        if dropout_rate is not None and dropout_rate > 0:
+            self.dropout = nnx.Dropout(dropout_rate, rngs=rngs)
+        else:
+            self.dropout = None
+
+    def _extract_patches(
+        self,
+        x: Float[Array, "batch height width in_channels"],
+    ) -> Float[Array, "batch out_height out_width kernel_h kernel_w in_channels"]:
+        """Extract patches (receptive fields) from the input using optimized JAX primitives."""
+        batch, height, width, in_channels = x.shape
+        kernel_h, kernel_w = self.kernel_size
+        stride_h, stride_w = self.stride
+
+        if self.padding == "SAME":
+            out_height = (height + stride_h - 1) // stride_h
+            out_width = (width + stride_w - 1) // stride_w
+            pad_h = max((out_height - 1) * stride_h + kernel_h - height, 0)
+            pad_w = max((out_width - 1) * stride_w + kernel_w - width, 0)
+            pad_top = pad_h // 2
+            pad_bottom = pad_h - pad_top
+            pad_left = pad_w // 2
+            pad_right = pad_w - pad_left
+
+            x = jnp.pad(
+                x,
+                ((0, 0), (pad_top, pad_bottom), (pad_left, pad_right), (0, 0)),
+                mode="edge",
+            )
+
+        patches_flat_BHW_CKhKw = jax.lax.conv_general_dilated_patches(
+            lhs=x,
+            filter_shape=(kernel_h, kernel_w),
+            window_strides=(stride_h, stride_w),
+            padding="VALID",
+            dimension_numbers=("NHWC", "OIHW", "NHWC"),
+        )
+
+        out_h, out_w = patches_flat_BHW_CKhKw.shape[1], patches_flat_BHW_CKhKw.shape[2]
+        patches_BHWCkhkw = patches_flat_BHW_CKhKw.reshape(batch, out_h, out_w, in_channels, kernel_h, kernel_w)
+        patches_BHWkhkwC = patches_BHWCkhkw.transpose(0, 1, 2, 4, 5, 3)
+
+        return patches_BHWkhkwC
+
+    def __call__(
+        self,
+        x: Float[Array, "batch height width in_channels"],
+        c: float = 1.0,
+        deterministic: bool = True,
+    ) -> Float[Array, "batch out_height out_width out_channels"]:
+        """Forward pass through the FHNN hyperbolic convolutional layer.
+
+        Parameters
+        ----------
+        x : Array of shape (batch, height, width, in_channels)
+            Input feature map where each pixel is a point on the Hyperboloid manifold
+        c : float
+            Manifold curvature (default: 1.0)
+        deterministic : bool
+            If True, dropout is disabled (default: True).
+
+        Returns
+        -------
+        out : Array of shape (batch, out_height, out_width, out_channels)
+            Output feature map on the Hyperboloid manifold
+        """
+        # Map to manifold if needed (static branch - JIT friendly)
+        if self.input_space == "tangent":
+            x_flat_NC = x.reshape(-1, x.shape[-1])  # (B*H*W, C)
+            x_mapped_NC = jax.vmap(self.manifold.expmap_0, in_axes=(0, None))(x_flat_NC, c)
+            x = x_mapped_NC.reshape(x.shape)  # (B, H, W, C)
+
+        # Extract patches: (B, H, W, kh, kw, C)
+        patches_BHWkhkwC = self._extract_patches(x)
+        batch, out_h, out_w, kh, kw, in_c = patches_BHWkhkwC.shape
+
+        # Flatten batch+spatial for parallel processing: (B*H*W, K, C)
+        patches_flat_NKC = patches_BHWkhkwC.reshape(-1, kh * kw, in_c)
+
+        # HCat: (K, C) -> (hcat_dim,) per patch
+        hcat_out_NA = jax.vmap(self.manifold.hcat, in_axes=(0, None))(patches_flat_NKC, c)  # (B*H*W, hcat_dim)
+
+        # Build dropout closure for the pure function
+        dropout_module = self.dropout
+        if dropout_module is not None:
+            dropout_fn = lambda z: dropout_module(z, deterministic=deterministic)  # noqa: E731
+        else:
+            dropout_fn = None
+
+        # FHNN linear: (hcat_dim,) -> (out_channels,)
+        linear_out_NC = _fhnn_forward(
+            hcat_out_NA,
+            self.kernel[...],
+            self.bias[...],
+            self.manifold,
+            c,
+            "manifold",  # HCat output is already on manifold
+            self.activation,
+            dropout_fn,
+            self.scale[...],
+            self.eps,
+        )  # (B*H*W, out_channels)
+
+        # Reshape back to spatial
+        return linear_out_NC.reshape(batch, out_h, out_w, self.out_channels)
 
 
 class FGGConv2D(nnx.Module):

--- a/hyperbolix/nn_layers/hyperboloid_linear.py
+++ b/hyperbolix/nn_layers/hyperboloid_linear.py
@@ -84,6 +84,68 @@ def _fhcnn_forward(
     return res_BA
 
 
+def _fhnn_forward(
+    x_BI: Float[Array, "batch in_dim"],
+    kernel_OI: Array,
+    bias_1O: Array,
+    manifold: Manifold,
+    c: float,
+    input_space: str,
+    activation: Callable[[Array], Array] | None,
+    dropout_fn: Callable[[Array], Array] | None,
+    scale_val: Array,
+    eps: float,
+) -> Float[Array, "batch out_dim"]:
+    """Pure-function FHNN forward pass (Chen et al. 2021).
+
+    Time-primary parameterization: the time coordinate is computed via scaled
+    sigmoid with an additive floor at 1/sqrt(c), and spatial coordinates are
+    rescaled so the output lies on the hyperboloid.
+    """
+    # Map to manifold if needed (static branch - JIT friendly)
+    if input_space == "tangent":
+        x_BI = jax.vmap(manifold.expmap_0, in_axes=(0, None), out_axes=0)(x_BI, c)
+
+    # Apply activation if provided (static branch - JIT friendly)
+    if activation is not None:
+        x_BI = activation(x_BI)
+
+    # Apply dropout if provided (static branch - JIT friendly)
+    if dropout_fn is not None:
+        x_BI = dropout_fn(x_BI)
+
+    # Linear transformation: (B, in_dim) -> (B, out_dim)
+    z_BO = jnp.einsum("bi,oi->bo", x_BI, kernel_OI) + bias_1O  # (B, O)
+
+    # Split into time logit and spatial components
+    z0_B1 = z_BO[:, 0:1]  # (B, 1)
+    z_rem_BD = z_BO[:, 1:]  # (B, D) where D = out_dim - 1
+
+    # Time coordinate via scaled sigmoid with floor at 1/sqrt(c)
+    # y0 > 1/sqrt(c) guaranteed by construction (additive floor, not max)
+    y0_B1 = jnp.exp(scale_val) * jax.nn.sigmoid(z0_B1) + 1.0 / jnp.sqrt(c) + eps  # (B, 1)
+
+    # Target spatial norm from hyperboloid constraint: ||y_s||^2 = y0^2 - 1/c
+    # Always real since y0 > 1/sqrt(c) + eps => y0^2 > 1/c
+    target_norm_B1 = jnp.sqrt(y0_B1**2 - 1.0 / c)  # (B, 1)
+
+    # Rescale spatial to satisfy hyperboloid constraint
+    z_rem_norm_B1 = jnp.linalg.norm(z_rem_BD, ord=2, axis=-1, keepdims=True)  # (B, 1)
+    z_rem_norm_safe_B1 = jnp.maximum(z_rem_norm_B1, eps)  # avoid division by zero
+    y_rem_BD = target_norm_B1 / z_rem_norm_safe_B1 * z_rem_BD  # (B, D)
+
+    # Concatenate time and spatial
+    res_BA = jnp.concatenate([y0_B1, y_rem_BD], axis=-1)  # (B, out_dim)
+
+    # Origin fallback: near-zero spatial norm -> hyperboloid origin
+    origin_time_B1 = jnp.full_like(y0_B1, 1.0 / jnp.sqrt(c))
+    origin_BA = jnp.concatenate([origin_time_B1, jnp.zeros_like(y_rem_BD)], axis=-1)
+    mask_B1 = z_rem_norm_B1 <= eps
+    res_BA = jnp.where(mask_B1, origin_BA, res_BA)
+
+    return res_BA
+
+
 def _hyperboloid_pp_forward(
     x_BAi: Float[Array, "batch in_dim"],
     kernel_OI: Array,
@@ -293,6 +355,156 @@ class HypLinearHyperboloidFHCNN(nnx.Module):
             self.activation,
             self.normalize,
             scale_val,
+            self.eps,
+        )
+
+
+class HypLinearHyperboloidFHNN(nnx.Module):
+    """Fully Hyperbolic Neural Networks linear layer (Chen et al. 2021).
+
+    Time-primary parameterization: the time coordinate is computed via scaled
+    sigmoid with an additive floor at 1/sqrt(c), and spatial coordinates are
+    rescaled so the output lies on the hyperboloid.
+
+    Computation steps:
+        0) Project the input tensor to the manifold (optional)
+        1) Apply activation (optional)
+        2) Apply dropout (optional)
+        3) Linear transform: z = W @ x + b
+        4) Time: y0 = exp(scale) * sigmoid(z0) + 1/sqrt(c) + eps
+        5) Spatial: y_rem = sqrt(y0^2 - 1/c) / ||z_rem|| * z_rem
+        6) Output: [y0, y_rem] on the hyperboloid
+
+    Parameters
+    ----------
+    manifold_module : object
+        Class-based Hyperboloid manifold instance
+    in_dim : int
+        Ambient input dimension (d+1, including time)
+    out_dim : int
+        Ambient output dimension (d+1, including time)
+    rngs : nnx.Rngs
+        Random number generators for parameter initialization
+    input_space : str
+        Type of the input tensor, either 'tangent' or 'manifold' (default: 'manifold').
+        Note: This is a static configuration - changing it after initialization requires recompilation.
+    init_scale : float
+        Initial value for the learnable sigmoid scale (default: 2.3)
+    eps : float
+        Numerical stability epsilon (default: 1e-5)
+    activation : callable or None
+        Activation function to apply before the linear transformation (default: None).
+        Note: This is a static configuration - changing it after initialization requires recompilation.
+    dropout_rate : float or None
+        Dropout rate applied before the linear transformation (default: None).
+
+    Notes
+    -----
+    JIT Compatibility:
+        This layer is designed to work with nnx.jit. Configuration parameters (input_space,
+        activation) are treated as static and will be baked into the compiled function.
+
+    Weight Initialization:
+        Weights are initialized as tangent vectors at the hyperboloid origin: U(-0.02, 0.02)
+        with the time column (column 0) zeroed. This matches the Chen et al. 2021 init.
+
+    Relationship to FHCNN:
+        Both FHNN and FHCNN ensure outputs lie on the hyperboloid, but differ in which
+        coordinate is primary. FHNN controls the time coordinate via sigmoid with an additive
+        floor at 1/sqrt(c), then derives the spatial norm from the hyperboloid constraint.
+        FHCNN (normalize=True) controls the spatial norm via sigmoid, then derives time.
+
+    See Also
+    --------
+    HypLinearHyperboloidFHCNN : FHCNN layer with spatial-primary parameterization.
+    HypLinearHyperboloidPP : HNN++ layer using MLR + sinh diffeomorphism.
+
+    References
+    ----------
+    Weize Chen, et al. "Fully hyperbolic neural networks."
+        arXiv preprint arXiv:2105.14686 (2021).
+    """
+
+    def __init__(
+        self,
+        manifold_module: Manifold,
+        in_dim: int,
+        out_dim: int,
+        *,
+        rngs: nnx.Rngs,
+        input_space: str = "manifold",
+        init_scale: float = 2.3,
+        eps: float = 1e-5,
+        activation: Callable[[Array], Array] | None = None,
+        dropout_rate: float | None = None,
+    ):
+        if input_space not in ["tangent", "manifold"]:
+            raise ValueError(f"input_space must be either 'tangent' or 'manifold', got '{input_space}'")
+
+        # Static configuration (treated as compile-time constants for JIT)
+        validate_hyperboloid_manifold(manifold_module, required_methods=("expmap_0",))
+        self.manifold = manifold_module
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+        self.input_space = input_space
+        self.eps = eps
+        self.activation = activation
+
+        # FHNN weight init: U(-0.02, 0.02) with time column zeroed (tangent vectors at origin)
+        bound = 0.02
+        weight_init = jax.random.uniform(rngs.params(), (out_dim, in_dim), minval=-bound, maxval=bound)
+        weight_init = weight_init.at[:, 0].set(0.0)
+        self.kernel = nnx.Param(weight_init)
+        self.bias = nnx.Param(jnp.zeros((1, out_dim)))
+
+        # Learnable scale for the sigmoid (always learnable in FHNN)
+        self.scale = nnx.Param(jnp.array(init_scale))
+
+        # Optional dropout
+        if dropout_rate is not None and dropout_rate > 0:
+            self.dropout = nnx.Dropout(dropout_rate, rngs=rngs)
+        else:
+            self.dropout = None
+
+    def __call__(
+        self,
+        x: Float[Array, "batch in_dim"],
+        c: float = 1.0,
+        deterministic: bool = True,
+    ) -> Float[Array, "batch out_dim"]:
+        """Forward pass through the FHNN hyperbolic linear layer.
+
+        Parameters
+        ----------
+        x : Array of shape (batch, in_dim)
+            Input tensor. x.shape[-1] must equal self.in_dim.
+        c : float
+            Manifold curvature (default: 1.0)
+        deterministic : bool
+            If True, dropout is disabled (default: True).
+
+        Returns
+        -------
+        res : Array of shape (batch, out_dim)
+            Output on the Hyperboloid manifold
+        """
+        # Build dropout closure for the pure function
+        dropout_module = self.dropout
+        if dropout_module is not None:
+            dropout_fn = lambda z: dropout_module(z, deterministic=deterministic)  # noqa: E731
+        else:
+            dropout_fn = None
+
+        return _fhnn_forward(
+            x,
+            self.kernel[...],
+            self.bias[...],
+            self.manifold,
+            c,
+            self.input_space,
+            self.activation,
+            dropout_fn,
+            self.scale[...],
             self.eps,
         )
 

--- a/tests/nn_layers/test_hyperboloid_conv_fhnn.py
+++ b/tests/nn_layers/test_hyperboloid_conv_fhnn.py
@@ -1,0 +1,250 @@
+"""Tests for HypConv2DHyperboloidFHNN (Chen et al. 2021 hyperboloid conv layer)."""
+
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from hyperbolix.manifolds import Hyperboloid
+from hyperbolix.nn_layers import HypConv2DHyperboloidFHNN
+
+
+@pytest.mark.parametrize("kernel_size", [1, 2, 3])
+@pytest.mark.parametrize("padding", ["SAME", "VALID"])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_output_shape(kernel_size, padding, dtype):
+    """Test HypConv2DHyperboloidFHNN output shape with different kernel sizes and padding."""
+    key = jax.random.PRNGKey(42)
+    manifold = Hyperboloid(dtype=dtype)
+    batch_size, height, width, in_channels, out_channels = 2, 8, 8, 3, 4
+    c = 1.0
+
+    x = jax.random.normal(key, (batch_size, height, width, in_channels), dtype=dtype) * 0.1
+    x_manifold = jax.vmap(jax.vmap(jax.vmap(lambda p: manifold.proj(p, c))))(x)
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DHyperboloidFHNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        rngs=rngs,
+        padding=padding,
+    )
+
+    y = layer(x_manifold, c=c)
+
+    if padding == "SAME":
+        expected_height, expected_width = height, width
+    else:
+        expected_height = height - kernel_size + 1
+        expected_width = width - kernel_size + 1
+
+    assert y.shape == (batch_size, expected_height, expected_width, out_channels)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_output_on_manifold(dtype):
+    """Test that all outputs lie on the Hyperboloid manifold."""
+    key = jax.random.PRNGKey(42)
+    manifold = Hyperboloid(dtype=dtype)
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
+    c = 1.0
+
+    x = jax.random.normal(key, (batch_size, height, width, in_channels), dtype=dtype) * 0.1
+    x_manifold = jax.vmap(jax.vmap(jax.vmap(lambda p: manifold.proj(p, c))))(x)
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DHyperboloidFHNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=rngs,
+        padding="SAME",
+    )
+
+    y = layer(x_manifold, c=c)
+
+    is_on_manifold = jax.vmap(jax.vmap(jax.vmap(lambda p: manifold.is_in_manifold(p, c))))(y)
+    assert is_on_manifold.all(), "Not all outputs lie on the manifold"
+
+
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_stride(stride, dtype):
+    """Test HypConv2DHyperboloidFHNN with different stride values."""
+    key = jax.random.PRNGKey(42)
+    manifold = Hyperboloid(dtype=dtype)
+    batch_size, height, width, in_channels, out_channels = 2, 8, 8, 3, 4
+    kernel_size = 3
+    c = 1.0
+
+    x = jax.random.normal(key, (batch_size, height, width, in_channels), dtype=dtype) * 0.1
+    x_manifold = jax.vmap(jax.vmap(jax.vmap(lambda p: manifold.proj(p, c))))(x)
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DHyperboloidFHNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        rngs=rngs,
+        padding="SAME",
+    )
+
+    y = layer(x_manifold, c=c)
+
+    expected_height = (height + stride - 1) // stride
+    expected_width = (width + stride - 1) // stride
+    assert y.shape == (batch_size, expected_height, expected_width, out_channels)
+
+
+@pytest.mark.parametrize("input_space", ["manifold", "tangent"])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_input_space(input_space, dtype):
+    """Test HypConv2DHyperboloidFHNN with different input_space settings."""
+    key = jax.random.PRNGKey(42)
+    manifold = Hyperboloid(dtype=dtype)
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
+    c = 1.0
+
+    x = jax.random.normal(key, (batch_size, height, width, in_channels), dtype=dtype) * 0.1
+
+    if input_space == "manifold":
+        x_input = jax.vmap(jax.vmap(jax.vmap(lambda p: manifold.proj(p, c))))(x)
+    else:
+        x_input = x.at[:, :, :, 0].set(0)
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DHyperboloidFHNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=rngs,
+        input_space=input_space,
+    )
+
+    y = layer(x_input, c=c)
+
+    is_on_manifold = jax.vmap(jax.vmap(jax.vmap(lambda p: manifold.is_in_manifold(p, c))))(y)
+    assert is_on_manifold.all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_gradient(dtype):
+    """Test HypConv2DHyperboloidFHNN has valid gradients (kernel, bias, scale)."""
+    key = jax.random.PRNGKey(42)
+    manifold = Hyperboloid(dtype=dtype)
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
+    c = 1.0
+
+    x = jax.random.normal(key, (batch_size, height, width, in_channels), dtype=dtype) * 0.1
+    x_manifold = jax.vmap(jax.vmap(jax.vmap(lambda p: manifold.proj(p, c))))(x)
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DHyperboloidFHNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=rngs,
+    )
+
+    def loss_fn(model):
+        y = model(x_manifold, c=c)
+        return jnp.sum(y**2)
+
+    loss, grads = nnx.value_and_grad(loss_fn)(layer)
+
+    assert jnp.isfinite(loss)
+    assert jnp.isfinite(grads.kernel[...]).all()
+    assert jnp.isfinite(grads.bias[...]).all()
+    assert jnp.isfinite(grads.scale[...])
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_jitted(dtype):
+    """Test HypConv2DHyperboloidFHNN under nnx.jit."""
+    key = jax.random.PRNGKey(42)
+    manifold = Hyperboloid(dtype=dtype)
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
+    c = 1.0
+
+    x = jax.random.normal(key, (batch_size, height, width, in_channels), dtype=dtype) * 0.1
+    x_manifold = jax.vmap(jax.vmap(jax.vmap(lambda p: manifold.proj(p, c))))(x)
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DHyperboloidFHNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=rngs,
+    )
+
+    @nnx.jit
+    def forward(module, inputs, curvature):
+        return module(inputs, c=curvature)
+
+    y = forward(layer, x_manifold, c)
+
+    is_on_manifold = jax.vmap(jax.vmap(jax.vmap(lambda p: manifold.is_in_manifold(p, c))))(y)
+    assert is_on_manifold.all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_different_curvatures(dtype):
+    """Test HypConv2DHyperboloidFHNN with different curvature values."""
+    key = jax.random.PRNGKey(42)
+    manifold = Hyperboloid(dtype=dtype)
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
+
+    for c in [0.5, 1.0, 2.0]:
+        x = jax.random.normal(key, (batch_size, height, width, in_channels), dtype=dtype) * 0.1
+        proj_fn = partial(manifold.proj, c=c)
+        x_manifold = jax.vmap(jax.vmap(jax.vmap(proj_fn)))(x)
+
+        rngs = nnx.Rngs(42)
+        layer = HypConv2DHyperboloidFHNN(
+            manifold_module=manifold,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=2,
+            rngs=rngs,
+        )
+
+        y = layer(x_manifold, c=c)
+
+        is_in_manifold_fn = partial(manifold.is_in_manifold, c=c)
+        is_on_manifold = jax.vmap(jax.vmap(jax.vmap(is_in_manifold_fn)))(y)
+        assert is_on_manifold.all(), f"Failed for curvature {c}"
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_time_floor(dtype):
+    """Test that FHNN conv time coordinate y0 >= 1/sqrt(c) always holds."""
+    key = jax.random.PRNGKey(42)
+    manifold = Hyperboloid(dtype=dtype)
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
+    c = 1.0
+
+    x = jax.random.normal(key, (batch_size, height, width, in_channels), dtype=dtype) * 0.1
+    x_manifold = jax.vmap(jax.vmap(jax.vmap(lambda p: manifold.proj(p, c))))(x)
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DHyperboloidFHNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=rngs,
+    )
+
+    y = layer(x_manifold, c=c)
+
+    assert (y[..., 0] >= 1.0 / jnp.sqrt(c)).all()

--- a/tests/nn_layers/test_hyperboloid_linear_fhnn.py
+++ b/tests/nn_layers/test_hyperboloid_linear_fhnn.py
@@ -1,0 +1,203 @@
+"""Tests for HypLinearHyperboloidFHNN (Chen et al. 2021 hyperboloid linear layer)."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from hyperbolix.manifolds.hyperboloid import Hyperboloid
+from hyperbolix.nn_layers import HypLinearHyperboloidFHNN
+
+
+def get_hyperboloid(dtype: jnp.dtype) -> Hyperboloid:
+    """Get dtype-specific Hyperboloid manifold instance."""
+    return Hyperboloid(dtype=dtype)
+
+
+def _check_on_hyperboloid(x, c, atol=1e-5):
+    """Check Minkowski constraint: -x0^2 + ||x_s||^2 = -1/c."""
+    mink = -(x[..., 0:1] ** 2) + jnp.sum(x[..., 1:] ** 2, axis=-1, keepdims=True)
+    return jnp.allclose(mink, -1.0 / c, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_forward_shape(dtype):
+    """Test HypLinearHyperboloidFHNN output shape and finiteness."""
+    key = jax.random.PRNGKey(42)
+    batch_size, in_dim, out_dim = 8, 6, 10
+
+    v = jax.random.normal(key, (batch_size, in_dim), dtype=dtype) * 0.1
+    x = jax.vmap(get_hyperboloid(dtype).expmap_0, in_axes=(0, None), out_axes=0)(v, 1.0)
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearHyperboloidFHNN(get_hyperboloid(dtype), in_dim, out_dim, rngs=rngs)
+
+    y = layer(x, c=1.0)
+
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_on_manifold(dtype):
+    """Test HypLinearHyperboloidFHNN output lies on the hyperboloid."""
+    key = jax.random.PRNGKey(42)
+    batch_size, in_dim, out_dim = 8, 6, 10
+    atol = 4e-3 if dtype == jnp.float32 else 1e-7
+
+    v = jax.random.normal(key, (batch_size, in_dim), dtype=dtype) * 0.1
+    x = jax.vmap(get_hyperboloid(dtype).expmap_0, in_axes=(0, None), out_axes=0)(v, 1.0)
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearHyperboloidFHNN(get_hyperboloid(dtype), in_dim, out_dim, rngs=rngs)
+
+    y = layer(x, c=1.0)
+
+    assert _check_on_hyperboloid(y, c=1.0, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_jitted_forward(dtype):
+    """Test HypLinearHyperboloidFHNN under nnx.jit."""
+    key = jax.random.PRNGKey(42)
+    batch_size, in_dim, out_dim = 8, 6, 10
+
+    v = jax.random.normal(key, (batch_size, in_dim), dtype=dtype) * 0.1
+    x = jax.vmap(get_hyperboloid(dtype).expmap_0, in_axes=(0, None), out_axes=0)(v, 1.0)
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearHyperboloidFHNN(get_hyperboloid(dtype), in_dim, out_dim, rngs=rngs)
+
+    @nnx.jit
+    def forward(module, inputs, curvature):
+        return module(inputs, c=curvature)
+
+    y = forward(layer, x, 1.0)
+
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_gradient(dtype):
+    """Test HypLinearHyperboloidFHNN has valid gradients (kernel, bias, scale)."""
+    key = jax.random.PRNGKey(42)
+    batch_size, in_dim, out_dim = 4, 6, 10
+
+    v = jax.random.normal(key, (batch_size, in_dim), dtype=dtype) * 0.1
+    x = jax.vmap(get_hyperboloid(dtype).expmap_0, in_axes=(0, None), out_axes=0)(v, 1.0)
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearHyperboloidFHNN(get_hyperboloid(dtype), in_dim, out_dim, rngs=rngs)
+
+    def loss_fn(model):
+        y = model(x, c=1.0)
+        return jnp.sum(y**2)
+
+    loss, grads = nnx.value_and_grad(loss_fn)(layer)
+
+    assert jnp.isfinite(loss)
+    assert jnp.isfinite(grads.kernel[...]).all()
+    assert jnp.isfinite(grads.bias[...]).all()
+    assert jnp.isfinite(grads.scale[...])
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_jitted_gradient(dtype):
+    """Test HypLinearHyperboloidFHNN gradients under nnx.jit."""
+    key = jax.random.PRNGKey(42)
+    batch_size, in_dim, out_dim = 4, 6, 10
+
+    v = jax.random.normal(key, (batch_size, in_dim), dtype=dtype) * 0.1
+    x = jax.vmap(get_hyperboloid(dtype).expmap_0, in_axes=(0, None), out_axes=0)(v, 1.0)
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearHyperboloidFHNN(get_hyperboloid(dtype), in_dim, out_dim, rngs=rngs)
+
+    @nnx.jit
+    def loss_fn(module, inputs, curvature):
+        y = module(inputs, c=curvature)
+        return jnp.sum(y**2)
+
+    loss, grads = nnx.value_and_grad(lambda model: loss_fn(model, x, 1.0))(layer)
+
+    assert jnp.isfinite(loss)
+    assert jnp.isfinite(grads.kernel[...]).all()
+    assert jnp.isfinite(grads.bias[...]).all()
+    assert jnp.isfinite(grads.scale[...])
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_tangent_input(dtype):
+    """Test HypLinearHyperboloidFHNN with tangent space input."""
+    key = jax.random.PRNGKey(42)
+    batch_size, in_dim, out_dim = 8, 6, 10
+    atol = 4e-3 if dtype == jnp.float32 else 1e-7
+
+    # Create tangent vector at origin (time coordinate is 0)
+    v = jax.random.normal(key, (batch_size, in_dim), dtype=dtype) * 0.1
+    v = v.at[:, 0].set(0.0)
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearHyperboloidFHNN(get_hyperboloid(dtype), in_dim, out_dim, rngs=rngs, input_space="tangent")
+
+    y = layer(v, c=1.0)
+
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+    assert _check_on_hyperboloid(y, c=1.0, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+@pytest.mark.parametrize("c", [0.5, 1.0, 2.0])
+def test_time_floor(dtype, c):
+    """Test that FHNN time coordinate y0 > 1/sqrt(c) always holds."""
+    key = jax.random.PRNGKey(42)
+    batch_size, in_dim, out_dim = 16, 6, 10
+
+    # Use larger magnitude inputs to stress-test the floor
+    v = jax.random.normal(key, (batch_size, in_dim), dtype=dtype) * 1.0
+    x = jax.vmap(get_hyperboloid(dtype).expmap_0, in_axes=(0, None), out_axes=0)(v, c)
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearHyperboloidFHNN(get_hyperboloid(dtype), in_dim, out_dim, rngs=rngs)
+
+    y = layer(x, c=c)
+
+    assert (y[:, 0] >= 1.0 / jnp.sqrt(c)).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_activation_and_dropout(dtype):
+    """Test HypLinearHyperboloidFHNN with activation and dropout."""
+    key = jax.random.PRNGKey(42)
+    batch_size, in_dim, out_dim = 8, 6, 10
+    atol = 4e-3 if dtype == jnp.float32 else 1e-7
+
+    v = jax.random.normal(key, (batch_size, in_dim), dtype=dtype) * 0.1
+    x = jax.vmap(get_hyperboloid(dtype).expmap_0, in_axes=(0, None), out_axes=0)(v, 1.0)
+
+    rngs = nnx.Rngs(params=42, dropout=43)
+    layer = HypLinearHyperboloidFHNN(
+        get_hyperboloid(dtype), in_dim, out_dim, rngs=rngs, activation=jax.nn.relu, dropout_rate=0.1
+    )
+
+    # deterministic=False (training mode)
+    y_train = layer(x, c=1.0, deterministic=False)
+    assert y_train.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y_train).all()
+    assert _check_on_hyperboloid(y_train, c=1.0, atol=atol)
+
+    # deterministic=True (eval mode)
+    y_eval = layer(x, c=1.0, deterministic=True)
+    assert y_eval.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y_eval).all()
+    assert _check_on_hyperboloid(y_eval, c=1.0, atol=atol)
+
+
+def test_init_time_column_zeroed():
+    """Test that FHNN initializes kernel time column (column 0) to zero."""
+    rngs = nnx.Rngs(42)
+    layer = HypLinearHyperboloidFHNN(get_hyperboloid(jnp.float32), 6, 10, rngs=rngs)
+
+    assert jnp.allclose(layer.kernel[...][:, 0], 0.0)


### PR DESCRIPTION
## Summary

Implement Fully Hyperbolic Neural Networks (FHNN) layers from Chen et al. 2021 for the Hyperboloid manifold.

**HypLinearHyperboloidFHNN**: Time-primary linear layer with:
- Sigmoid + floor parameterization for time coordinate: `y0 = exp(scale) * sigmoid(z0) + 1/sqrt(c) + eps`
- Spatial rescaling from hyperboloid constraint
- Always-learnable scale parameter
- Optional activation and dropout support

**HypConv2DHyperboloidFHNN**: Convolutional layer using HCat patch extraction + FHNN linear transformation
- Supports all standard conv parameters (kernel size, stride, padding)
- Full test coverage with shape/manifold/gradient validation

## Test plan

- [x] 21 linear layer tests covering shape, manifold constraint, JIT, gradients, tangent space, time floor
- [x] 30 convolutional layer tests covering output shapes, strides, manifolds, curvatures, time floor
- [x] All tests parametrized across float32/float64
- [x] Pre-commit hooks: isort, ruff, pyright all passing
- [x] No regressions: existing 44 conv tests still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)