### PR TITLE
feat: Add hyp_avg_pool2d global average pooling for hyperboloid manifolds

### DIFF
--- a/benchmarks/bench_mnist_hyperboloid.py
+++ b/benchmarks/bench_mnist_hyperboloid.py
@@ -60,6 +60,7 @@ from hyperbolix.nn_layers import (
     HypRegressionHyperboloid,
     LorentzConv2D,
     hrc_relu,
+    hyp_avg_pool2d,
 )
 
 # Enable float64 for numerical stability
@@ -424,13 +425,7 @@ class FullyHyperbolicCNN_HCat(nnx.Module):
         x = self.hyp_bn2(x, c_in=c, c_out=c, use_running_average=use_running_average)  # (batch, 7, 7, 65)
 
         # Global average pooling in hyperbolic space
-        # Extract spatial components, pool, reconstruct time
-        x_space = x[..., 1:]  # (batch, 7, 7, 64)
-        x_space_pooled = jnp.mean(x_space, axis=(1, 2))  # (batch, 64)
-
-        # Reconstruct as hyperboloid point
-        time_coord = jnp.sqrt(jnp.sum(x_space_pooled**2, axis=-1, keepdims=True) + 1 / c)  # (batch, 1)
-        x = jnp.concatenate([time_coord, x_space_pooled], axis=-1)  # (batch, 65)
+        x = hyp_avg_pool2d(x, c)  # (batch, 65)
 
         # Hyperbolic linear layer
         x = self.hyp_linear(x, c)  # (batch, 65)
@@ -518,13 +513,7 @@ class FullyHyperbolicCNN_Lorentz(nnx.Module):
         x = hrc_relu(x, c, c)
 
         # Global average pooling in hyperbolic space
-        # Extract spatial components, pool, reconstruct time
-        x_space = x[..., 1:]  # (batch, 7, 7, 64)
-        x_space_pooled = jnp.mean(x_space, axis=(1, 2))  # (batch, 64)
-
-        # Reconstruct as hyperboloid point
-        time_coord = jnp.sqrt(jnp.sum(x_space_pooled**2, axis=-1, keepdims=True) + 1 / c)  # (batch, 1)
-        x = jnp.concatenate([time_coord, x_space_pooled], axis=-1)  # (batch, 65)
+        x = hyp_avg_pool2d(x, c)  # (batch, 65)
 
         # Hyperbolic linear layer
         x = self.hyp_linear(x, c)  # (batch, 65)
@@ -712,11 +701,8 @@ class FullyHyperbolicCNN_FGG(nnx.Module):
         x = self.hyp_conv2(x, c)  # (batch, 7, 7, 65)
         x = self.hyp_bn2(x, c_in=c, c_out=c, use_running_average=use_running_average)
 
-        # Global average pooling (spatial pool + time reconstruct)
-        x_space = x[..., 1:]  # (batch, 7, 7, 64)
-        x_space_pooled = jnp.mean(x_space, axis=(1, 2))  # (batch, 64)
-        time_coord = jnp.sqrt(jnp.sum(x_space_pooled**2, axis=-1, keepdims=True) + 1 / c)
-        x = jnp.concatenate([time_coord, x_space_pooled], axis=-1)  # (batch, 65)
+        # Global average pooling in hyperbolic space
+        x = hyp_avg_pool2d(x, c)  # (batch, 65)
 
         # FGG linear + MLR
         x = self.hyp_linear(x, c)  # (batch, 65)

--- a/hyperbolix/nn_layers/__init__.py
+++ b/hyperbolix/nn_layers/__init__.py
@@ -20,7 +20,15 @@ from .hyperboloid_attention import (
     focus_transform,
 )
 from .hyperboloid_conv import FGGConv2D, HypConv2DHyperboloid, HypConv2DHyperboloidFHNN, HypConv2DHyperboloidPP, LorentzConv2D
-from .hyperboloid_core import build_spacelike_V, hrc, htc, lorentz_midpoint, lorentz_residual, spatial_to_hyperboloid
+from .hyperboloid_core import (
+    build_spacelike_V,
+    hrc,
+    htc,
+    hyp_avg_pool2d,
+    lorentz_midpoint,
+    lorentz_residual,
+    spatial_to_hyperboloid,
+)
 from .hyperboloid_linear import (
     FGGLinear,
     HTCLinear,
@@ -78,6 +86,7 @@ __all__ = [
     "hrc_swish",
     "hrc_tanh",
     "htc",
+    "hyp_avg_pool2d",
     "hyp_gelu",
     "hyp_leaky_relu",
     "hyp_relu",

--- a/hyperbolix/nn_layers/hyperboloid_core.py
+++ b/hyperbolix/nn_layers/hyperboloid_core.py
@@ -216,6 +216,84 @@ def lorentz_residual(
     return ave_A / denom_1  # (..., A)
 
 
+def hyp_avg_pool2d(
+    x: Float[Array, "... H W dim_plus_1"],
+    c: float,
+    eps: float = 1e-7,
+) -> Float[Array, "... dim_plus_1"]:
+    """Global average pooling over 2D spatial dimensions on the hyperboloid.
+
+    Averages the spatial components over the height and width dimensions,
+    then reconstructs the time component via the hyperboloid constraint.
+    This is the HRC pattern with ``f_r = mean_over_spatial``:
+
+    .. math::
+
+        \\text{space} = \\text{mean}_{H,W}(x[..., 1:])
+
+        x_0 = \\sqrt{\\|\\text{space}\\|^2 + 1/c}
+
+        \\text{output} = [x_0, \\text{space}]
+
+    The function expects the **NHWC** layout used throughout hyperbolix:
+    ``(..., H, W, ambient_dim)`` where ``ambient_dim = spatial_dim + 1``.
+
+    This operation is **hyperboloid-only** because it relies on the time/spatial
+    decomposition ``x[..., 0]`` (time) and ``x[..., 1:]`` (spatial). Poincaré
+    ball points do not have a time component. To pool Poincaré features, first
+    convert to hyperboloid via
+    :func:`~hyperbolix.manifolds.isometry_mappings.poincare_to_hyperboloid`,
+    pool, then convert back.
+
+    Parameters
+    ----------
+    x : Array, shape (..., H, W, dim+1)
+        Hyperboloid feature map with curvature ``c``.  The last axis is
+        the ambient dimension (time + spatial).  The two axes before it
+        are the spatial height ``H`` and width ``W``.
+    c : float
+        Curvature parameter (positive, c > 0).
+    eps : float, optional
+        Numerical stability floor for the time reconstruction
+        (default: 1e-7).
+
+    Returns
+    -------
+    Array, shape (..., dim+1)
+        Pooled hyperboloid points with curvature ``c``.
+
+    See Also
+    --------
+    spatial_to_hyperboloid : Low-level curvature scaling + time reconstruction.
+    hrc : General HRC wrapper for arbitrary Euclidean functions.
+    lorentz_midpoint : Weighted Lorentzian midpoint (geometrically exact aggregation).
+
+    Examples
+    --------
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from hyperbolix.manifolds import Hyperboloid
+    >>> from hyperbolix.nn_layers.hyperboloid_core import hyp_avg_pool2d
+    >>>
+    >>> hyperboloid = Hyperboloid(dtype=jnp.float32)
+    >>> key = jax.random.PRNGKey(0)
+    >>> v = jax.random.normal(key, (4, 7, 7, 64), dtype=jnp.float32) * 0.1
+    >>> x = jax.vmap(jax.vmap(jax.vmap(
+    ...     hyperboloid.expmap_0, in_axes=(0, None)
+    ... ), in_axes=(0, None)), in_axes=(0, None))(v, 1.0)
+    >>> x.shape
+    (4, 7, 7, 65)
+    >>> y = hyp_avg_pool2d(x, c=1.0)
+    >>> y.shape
+    (4, 65)
+    """
+    # Dimension key: H=height, W=width, D=spatial_dim, A=ambient_dim (D+1)
+
+    x_space_HWD = x[..., 1:]  # (..., H, W, D) — drop time coordinate
+    x_pooled_D = jnp.mean(x_space_HWD, axis=(-3, -2))  # (..., D)
+    return spatial_to_hyperboloid(x_pooled_D, c_in=c, c_out=c, eps=eps)  # (..., D+1)
+
+
 def hrc(
     x: Float[Array, "... dim_plus_1"],
     f_r: Callable[[Float[Array, "..."]], Float[Array, "..."]],

--- a/tests/nn_layers/test_hyperboloid_pool.py
+++ b/tests/nn_layers/test_hyperboloid_pool.py
@@ -1,0 +1,236 @@
+"""Tests for hyp_avg_pool2d — hyperbolic 2D global average pooling."""
+
+import functools
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from hyperbolix.manifolds.hyperboloid import Hyperboloid
+from hyperbolix.nn_layers.hyperboloid_core import hrc, hyp_avg_pool2d
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_hyperboloid_feature_map(key, batch, height, width, spatial_dim, c, dtype):
+    """Generate a valid hyperboloid feature map of shape (batch, H, W, spatial_dim+1).
+
+    Parameters
+    ----------
+    spatial_dim : int
+        Spatial dimension.  Ambient (output) dimension is spatial_dim + 1.
+    """
+    hyperboloid = Hyperboloid(dtype=dtype)
+    # Tangent vectors at origin have zero time component: [0, v_1, ..., v_d]
+    v_spatial = jax.random.normal(key, (batch, height, width, spatial_dim), dtype=dtype) * 0.1
+    v = jnp.concatenate([jnp.zeros_like(v_spatial[..., :1]), v_spatial], axis=-1)  # (..., d+1)
+    proj = jax.vmap(
+        jax.vmap(jax.vmap(hyperboloid.expmap_0, in_axes=(0, None)), in_axes=(0, None)),
+        in_axes=(0, None),
+    )
+    return proj(v, c)
+
+
+# ============================================================================
+# Shape Tests
+# ============================================================================
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pool_shape_4d(dtype):
+    """(B, H, W, A) -> (B, A) where A = spatial_dim + 1."""
+    key = jax.random.PRNGKey(0)
+    x = _make_hyperboloid_feature_map(key, batch=4, height=7, width=7, spatial_dim=64, c=1.0, dtype=dtype)
+    assert x.shape == (4, 7, 7, 65)
+    y = hyp_avg_pool2d(x, c=1.0)
+    assert y.shape == (4, 65)
+
+
+def test_pool_shape_3d():
+    """(H, W, A) -> (A,)."""
+    hyperboloid = Hyperboloid(dtype=jnp.float32)
+    key = jax.random.PRNGKey(1)
+    # Tangent vectors at origin: [0, v_1, ..., v_8] → ambient dim 9
+    v_spatial = jax.random.normal(key, (3, 3, 8), dtype=jnp.float32) * 0.1
+    v = jnp.concatenate([jnp.zeros_like(v_spatial[..., :1]), v_spatial], axis=-1)
+    x = jax.vmap(jax.vmap(hyperboloid.expmap_0, in_axes=(0, None)), in_axes=(0, None))(v, 1.0)
+    assert x.shape == (3, 3, 9)
+    y = hyp_avg_pool2d(x, c=1.0)
+    assert y.shape == (9,)
+
+
+def test_pool_shape_5d():
+    """(B1, B2, H, W, A) -> (B1, B2, A)."""
+    key = jax.random.PRNGKey(2)
+    # Build (6, H, W, 17) then reshape to (2, 3, H, W, 17)
+    x = _make_hyperboloid_feature_map(key, batch=6, height=4, width=4, spatial_dim=16, c=1.0, dtype=jnp.float32)
+    assert x.shape == (6, 4, 4, 17)
+    x = x.reshape(2, 3, 4, 4, 17)
+    y = hyp_avg_pool2d(x, c=1.0)
+    assert y.shape == (2, 3, 17)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pool_dtype_preserved(dtype):
+    """Output dtype matches input dtype."""
+    key = jax.random.PRNGKey(3)
+    x = _make_hyperboloid_feature_map(key, batch=2, height=3, width=3, spatial_dim=8, c=1.0, dtype=dtype)
+    y = hyp_avg_pool2d(x, c=1.0)
+    assert y.dtype == dtype
+
+
+# ============================================================================
+# Manifold Constraint Tests
+# ============================================================================
+
+
+@pytest.mark.parametrize("c", [0.5, 1.0, 2.0])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pool_manifold_constraint(dtype, c):
+    """All output points satisfy the hyperboloid constraint."""
+    hyperboloid = Hyperboloid(dtype=dtype)
+    key = jax.random.PRNGKey(10)
+    x = _make_hyperboloid_feature_map(key, batch=8, height=4, width=4, spatial_dim=16, c=c, dtype=dtype)
+    y = hyp_avg_pool2d(x, c=c)  # (8, 17)
+
+    is_valid = jax.vmap(hyperboloid.is_in_manifold, in_axes=(0, None))(y, c)
+    assert is_valid.all()
+
+
+@pytest.mark.parametrize("hw", [1, 3, 7, 14])
+def test_pool_manifold_various_spatial(hw):
+    """Manifold constraint holds for various spatial sizes."""
+    hyperboloid = Hyperboloid(dtype=jnp.float64)
+    key = jax.random.PRNGKey(20)
+    x = _make_hyperboloid_feature_map(key, batch=4, height=hw, width=hw, spatial_dim=8, c=1.0, dtype=jnp.float64)
+    y = hyp_avg_pool2d(x, c=1.0)
+
+    is_valid = jax.vmap(hyperboloid.is_in_manifold, in_axes=(0, None))(y, 1.0)
+    assert is_valid.all()
+
+
+# ============================================================================
+# Correctness Tests
+# ============================================================================
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pool_matches_manual(dtype):
+    """Output matches the hand-rolled extract+pool+reconstruct pattern."""
+    key = jax.random.PRNGKey(30)
+    c = 1.0
+    x = _make_hyperboloid_feature_map(key, batch=4, height=7, width=7, spatial_dim=32, c=c, dtype=dtype)
+
+    # Hand-rolled (the pattern from benchmarks)
+    x_space = x[..., 1:]  # (4, 7, 7, 32)
+    x_pooled = jnp.mean(x_space, axis=(1, 2))  # (4, 32)
+    time_coord = jnp.sqrt(jnp.sum(x_pooled**2, axis=-1, keepdims=True) + 1.0 / c)
+    expected = jnp.concatenate([time_coord, x_pooled], axis=-1)  # (4, 33)
+
+    y = hyp_avg_pool2d(x, c=c)
+
+    atol = 4e-3 if dtype == jnp.float32 else 1e-7
+    assert jnp.allclose(y, expected, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pool_matches_hrc(dtype):
+    """Output matches hrc(x, pool_fn, c, c)."""
+    key = jax.random.PRNGKey(31)
+    c = 1.5
+    x = _make_hyperboloid_feature_map(key, batch=4, height=4, width=4, spatial_dim=16, c=c, dtype=dtype)
+
+    pool_fn = functools.partial(jnp.mean, axis=(-3, -2))
+    expected = hrc(x, pool_fn, c_in=c, c_out=c)
+    y = hyp_avg_pool2d(x, c=c)
+
+    atol = 4e-3 if dtype == jnp.float32 else 1e-7
+    assert jnp.allclose(y, expected, atol=atol)
+
+
+def test_pool_1x1_identity():
+    """When H=W=1, spatial components pass through unchanged."""
+    key = jax.random.PRNGKey(32)
+    c = 1.0
+    x = _make_hyperboloid_feature_map(key, batch=4, height=1, width=1, spatial_dim=16, c=c, dtype=jnp.float64)
+
+    y = hyp_avg_pool2d(x, c=c)  # (4, 17)
+    # Squeeze H,W from input for comparison
+    x_squeezed = x[:, 0, 0, :]  # (4, 17)
+
+    assert jnp.allclose(y, x_squeezed, atol=1e-7)
+
+
+def test_pool_uniform_spatial():
+    """When all spatial positions are identical, output equals that point."""
+    hyperboloid = Hyperboloid(dtype=jnp.float64)
+    key = jax.random.PRNGKey(33)
+    c = 1.0
+
+    # Create a single hyperboloid point and tile across H, W
+    v = jax.random.normal(key, (4, 8), dtype=jnp.float64) * 0.1
+    points = jax.vmap(hyperboloid.expmap_0, in_axes=(0, None))(v, c)  # (4, 9)
+    x = jnp.tile(points[:, None, None, :], (1, 5, 5, 1))  # (4, 5, 5, 9)
+
+    y = hyp_avg_pool2d(x, c=c)  # (4, 9)
+
+    assert jnp.allclose(y, points, atol=1e-7)
+
+
+# ============================================================================
+# Gradient Tests
+# ============================================================================
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pool_gradients_finite(dtype):
+    """Gradients through hyp_avg_pool2d are finite."""
+    key = jax.random.PRNGKey(40)
+    c = 1.0
+    x = _make_hyperboloid_feature_map(key, batch=2, height=4, width=4, spatial_dim=8, c=c, dtype=dtype)
+
+    def loss_fn(x_in):
+        y = hyp_avg_pool2d(x_in, c=c)
+        return jnp.sum(y**2)
+
+    grads = jax.grad(loss_fn)(x)
+    assert grads.shape == x.shape
+    assert jnp.all(jnp.isfinite(grads))
+
+
+# ============================================================================
+# JIT Compatibility Tests
+# ============================================================================
+
+
+def test_pool_jit():
+    """JIT-compiled output matches eager execution."""
+    key = jax.random.PRNGKey(50)
+    c = 1.0
+    x = _make_hyperboloid_feature_map(key, batch=4, height=4, width=4, spatial_dim=16, c=c, dtype=jnp.float64)
+
+    y_eager = hyp_avg_pool2d(x, c=c)
+    y_jit = jax.jit(hyp_avg_pool2d, static_argnames="c")(x, c=c)
+
+    assert jnp.allclose(y_eager, y_jit, atol=1e-10)
+
+
+# ============================================================================
+# Curvature Tests
+# ============================================================================
+
+
+@pytest.mark.parametrize("c", [0.5, 1.0, 2.0, 5.0])
+def test_pool_different_curvatures(c):
+    """Function produces valid, finite outputs for various curvatures."""
+    hyperboloid = Hyperboloid(dtype=jnp.float64)
+    key = jax.random.PRNGKey(60)
+    x = _make_hyperboloid_feature_map(key, batch=4, height=4, width=4, spatial_dim=8, c=c, dtype=jnp.float64)
+
+    y = hyp_avg_pool2d(x, c=c)
+
+    assert jnp.all(jnp.isfinite(y))
+    is_valid = jax.vmap(hyperboloid.is_in_manifold, in_axes=(0, None))(y, c)
+    assert is_valid.all()


### PR DESCRIPTION
## Summary

Implements `hyp_avg_pool2d()` — global average pooling for hyperboloid feature maps. Extracts spatial components, averages over H×W spatial dimensions, and reconstructs the time coordinate via the hyperboloid constraint.

## Design

- **Hyperboloid-only**: Relies on time/spatial decomposition (`x[..., 0]` = time, `x[..., 1:]` = spatial)
- **No exp/log maps**: Reuses `spatial_to_hyperboloid()` for efficient time reconstruction
- **Arbitrary batch dims**: Works with shape `(..., H, W, dim+1)` → `(..., dim+1)`
- **Poincaré users**: Compose with `poincare_to_hyperboloid` → pool → `hyperboloid_to_poincare`

## Changes

- `hyp_avg_pool2d()` in `hyperboloid_core.py` (78 new lines)
- Export in `nn_layers/__init__.py`
- 29 unit tests: shapes, manifold constraint, manual equivalence, HRC equivalence, gradients, JIT, curvatures
- Refactor 3 benchmark models to use the function instead of inline pooling

## Testing

- ✅ 29 new pool tests pass
- ✅ Full test suite passes (~1660 tests, 72 skipped)
- ✅ Linting + type checking clean (ruff, pyright)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>