### PR TITLE
docs: Add Proper Velocity manifold and layers to API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Pure JAX implementation of hyperbolic deep learning with manifold operations, ne
 
 ## Features
 
-- 🌐 **3 Manifolds**: Euclidean, Poincaré Ball, Hyperboloid
-- 🧠 **13+ Neural Network Layers**: Linear, convolutional, regression
-- ⚡ **4 Hyperbolic Activations**: ReLU, Leaky ReLU, Tanh, Swish
+- 🌐 **4 Manifolds**: Euclidean, Poincaré Ball, Hyperboloid, Proper Velocity
+- 🧠 **20+ Neural Network Layers**: Linear, convolutional, regression, attention, positional encoding, PV
+- ⚡ **5 Hyperbolic Activations**: ReLU, Leaky ReLU, Tanh, Swish, GELU
 - 📈 **Riemannian Optimizers**: RAdam and RSGD with automatic manifold detection
 - 🚀 **Pure JAX/Flax NNX**: vmap-native API, JIT-compatible (10-100x speedup)
 - ✅ **1,400+ tests passing** with comprehensive benchmark suite
@@ -101,6 +101,8 @@ Implements methods from:
 - Shimizu et al. (2020): Hyperbolic Neural Networks++
 - Bdeir et al. (2023): Fully Hyperbolic CNNs
 - Bdeir et al. (2025): Robust Hyperbolic Learning
+- Klis et al. (2026): Fast and Geometrically Grounded Lorentz Neural Networks
+- Chen et al. (2026): Proper Velocity Neural Networks
 
 See individual module docstrings for detailed references.
 

--- a/benchmarks/bench_mnist_pv.py
+++ b/benchmarks/bench_mnist_pv.py
@@ -1,0 +1,277 @@
+"""MNIST benchmark for Proper Velocity (PV) neural network layers.
+
+Compares two fully-hyperbolic PV variants — no Euclidean embedding layers:
+
+- PVDirect:  expmap_0(784) + HypLinearPV stack + HypRegressionPV
+- PV-CNN:    HypConv2DPV + relu + HypConv2DPV + relu + GAP + HypLinearPV + HypRegressionPV
+
+Both models classify entirely on the PV manifold (HypRegressionPV head).
+
+Metrics: memory footprint, wallclock time, accuracy.
+
+Run with:
+    uv run python benchmarks/bench_mnist_pv.py [OPTIONS]
+
+Examples:
+    # Run both models
+    uv run python benchmarks/bench_mnist_pv.py
+
+    # Run only the direct FC model
+    uv run python benchmarks/bench_mnist_pv.py --pv-direct
+
+    # Run only the PV CNN
+    uv run python benchmarks/bench_mnist_pv.py --pv-cnn
+"""
+
+import argparse
+import json
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jaxtyping import Array, Float
+
+from benchmarks.utils import (
+    benchmark_model,
+    load_mnist_data,
+    plot_comparison,
+    print_summary_table,
+)
+from hyperbolix.manifolds import ProperVelocity
+from hyperbolix.nn_layers import (
+    HypConv2DPV,
+    HypLinearPV,
+    HypRegressionPV,
+)
+
+# Enable float64 for numerical stability
+jax.config.update("jax_enable_x64", True)
+
+# Class-based manifold instance for NN layers
+pv = ProperVelocity(dtype=jnp.float64)
+
+# Default curvature. Chen et al. 2026 use K = -0.5 for PV on CIFAR with a
+# ResNet-18 + PVManifoldMLR head, paired with lr=1e-1, weight decay, and 200
+# epochs. Our MNIST benchmark runs only 5 epochs at lr=1e-2 (hardcoded in
+# benchmarks/utils.py), so the paper's c=0.5 undertrains in our budget: we
+# use c=0.1 which converges cleanly for PV-Direct in 5 epochs. The paper also
+# references a learnable-curvature config (`learn_k = True`); we deliberately
+# keep curvature fixed here to keep the MNIST benchmark simple.
+DEFAULT_C = 0.1
+
+
+# ==============================================================================
+# Model Definitions
+# ==============================================================================
+
+
+class PVDirect(nnx.Module):
+    """Fully-hyperbolic PV FC with direct pixel-to-manifold projection.
+
+    No Euclidean preprocessing: raw pixels are mapped onto the PV manifold via
+    ``expmap_0``, then passed through a PV-only stack. PV advertises stability
+    at large radii, so we do not pre-scale the input (unlike the Poincaré
+    analogue, where a 0.01 pre-scale is needed to avoid ball-boundary saturation).
+
+    Architecture:
+        Input (784) → expmap_0 to PV (784-dim)
+                   → HypLinearPV(784→64) + ReLU (on PV manifold)
+                   → HypLinearPV(64→64)
+                   → HypRegressionPV(64→10 classes)
+    """
+
+    def __init__(self, rngs: nnx.Rngs):
+        self.hyp1 = HypLinearPV(manifold_module=pv, in_dim=784, out_dim=64, rngs=rngs)
+        self.hyp2 = HypLinearPV(manifold_module=pv, in_dim=64, out_dim=64, rngs=rngs)
+        self.output = HypRegressionPV(manifold_module=pv, in_dim=64, out_dim=10, rngs=rngs)
+
+    def __call__(
+        self, x: Float[Array, "batch 784"], c: float = 1.0, use_running_average: bool = False
+    ) -> Float[Array, "batch 10"]:
+        del use_running_average  # no BatchNorm in PV layers (yet)
+        # Project raw pixels directly to PV — no scaling. PV's unbounded
+        # geometry handles large radii without boundary saturation.
+        x = jax.vmap(pv.expmap_0, in_axes=(0, None))(x, c)  # (batch, 784)
+
+        # PV layers. ReLU works directly on PV points (paper Sec 5.3).
+        x = self.hyp1(x, c)  # (batch, 64)
+        x = jax.nn.relu(x)
+        x = self.hyp2(x, c)  # (batch, 64)
+
+        # PV MLR classification
+        return self.output(x, c)  # (batch, 10)
+
+
+class FullyHyperbolicCNN_PV(nnx.Module):
+    """Fully-hyperbolic CNN built entirely on the PV manifold.
+
+    Unlike the Poincaré conv (which round-trips through the tangent space), the
+    PV conv consumes and produces points on the PV manifold directly — ReLU can
+    be applied in PV space between layers (paper Sec 5.3). The first conv lifts
+    raw pixels via ``expmap_0`` (``input_space="tangent"``); subsequent layers
+    stay on the manifold.
+
+    Architecture:
+        Input (batch, 784)
+        → reshape (batch, 28, 28, 1)
+        → HypConv2DPV(1→32, k=3, stride=2, SAME, input_space="tangent") + ReLU
+        → HypConv2DPV(32→64, k=3, stride=2, SAME, input_space="manifold") + ReLU
+        → GAP (mean over spatial dims — still a PV point, since PV is R^n)
+        → HypLinearPV(64→64) + ReLU
+        → HypRegressionPV(64→10)
+
+    Init note
+    ---------
+    Relies on ``HypConv2DPV`` / ``HypLinearPV`` defaulting to He(fan_in) kernel
+    init — required for a deep fully-hyperbolic stack to preserve variance
+    under ReLU. The paper's ``std=1e-2`` default (kept on ``HypRegressionPV``)
+    is tuned for a single MLR head receiving ``O(1)``-variance features from a
+    well-initialized backbone and would otherwise cause ~50,000x signal
+    attenuation here, pinning logits at O(1e-4) and softmax at uniform.
+    """
+
+    def __init__(self, rngs: nnx.Rngs):
+        self.hyp_conv1 = HypConv2DPV(
+            manifold_module=pv,
+            in_channels=1,
+            out_channels=32,
+            kernel_size=3,
+            rngs=rngs,
+            stride=2,
+            padding="SAME",
+            input_space="tangent",  # raw pixels → expmap_0 inside the layer
+        )
+        self.hyp_conv2 = HypConv2DPV(
+            manifold_module=pv,
+            in_channels=32,
+            out_channels=64,
+            kernel_size=3,
+            rngs=rngs,
+            stride=2,
+            padding="SAME",
+            input_space="manifold",  # conv1 output already on PV
+        )
+        self.hyp_linear = HypLinearPV(
+            manifold_module=pv,
+            in_dim=64,
+            out_dim=64,
+            rngs=rngs,
+            input_space="manifold",
+        )
+        self.output = HypRegressionPV(
+            manifold_module=pv,
+            in_dim=64,
+            out_dim=10,
+            rngs=rngs,
+            input_space="manifold",
+        )
+
+    def __call__(
+        self, x: Float[Array, "batch 784"], c: float = 1.0, use_running_average: bool = False
+    ) -> Float[Array, "batch 10"]:
+        del use_running_average
+        # (batch, 784) → (batch, 28, 28, 1)
+        x = x.reshape(-1, 28, 28, 1)
+
+        # First PV conv block (tangent in → manifold out)
+        x = self.hyp_conv1(x, c)  # (batch, 14, 14, 32) on PV
+        x = jax.nn.relu(x)
+
+        # Second PV conv block (manifold in → manifold out)
+        x = self.hyp_conv2(x, c)  # (batch, 7, 7, 64) on PV
+        x = jax.nn.relu(x)
+
+        # Global average pooling. PV is R^n, so spatial mean is still a PV point.
+        x = jnp.mean(x, axis=(1, 2))  # (batch, 64) on PV
+
+        # PV linear + MLR head
+        x = self.hyp_linear(x, c)  # (batch, 64)
+        x = jax.nn.relu(x)
+        return self.output(x, c)  # (batch, 10)
+
+
+# ==============================================================================
+# Main
+# ==============================================================================
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="MNIST benchmark for fully-hyperbolic Proper Velocity models",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Run both models (default)
+  python benchmarks/bench_mnist_pv.py
+
+  # Run only the direct FC model
+  python benchmarks/bench_mnist_pv.py --pv-direct
+
+  # Run only the PV CNN
+  python benchmarks/bench_mnist_pv.py --pv-cnn
+        """,
+    )
+
+    parser.add_argument("--pv-direct", action="store_true", help="Run PV FC with direct pixel projection")
+    parser.add_argument("--pv-cnn", action="store_true", help="Run fully-hyperbolic PV CNN")
+    parser.add_argument("--all", action="store_true", help="Run all models (default if no flags specified)")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility (default: 42)")
+    parser.add_argument("--c", type=float, default=DEFAULT_C, help=f"Manifold curvature (default: {DEFAULT_C})")
+
+    return parser.parse_args()
+
+
+def main():
+    """Run benchmarks based on command line arguments."""
+    args = parse_args()
+
+    run_all = args.all or not (args.pv_direct or args.pv_cnn)
+
+    available_models = [
+        (PVDirect, "PV-Direct", args.pv_direct or run_all),
+        (FullyHyperbolicCNN_PV, "PV-CNN", args.pv_cnn or run_all),
+    ]
+
+    models = [(cls, name) for cls, name, should_run in available_models if should_run]
+
+    if not models:
+        print("No models selected. Use --help to see available options.")
+        return
+
+    print("=" * 60)
+    print("MNIST Proper Velocity Layer Benchmark")
+    print("=" * 60)
+    print(f"\nRunning {len(models)} model(s): {', '.join(name for _, name in models)}")
+    print(f"Random seed: {args.seed}")
+    print(f"Curvature c: {args.c}")
+    print("\nLoading MNIST data...")
+    train_data, test_data = load_mnist_data()
+
+    results = {}
+    for model_class, name in models:
+        print(f"\n{'=' * 60}")
+        print(f"Benchmarking {name}")
+        print("=" * 60)
+        results[name] = benchmark_model(model_class, name, train_data, test_data, seed=args.seed, c=args.c, batch_size=128)
+
+    # Save results
+    print("\nSaving results...")
+    with open("results/mnist_pv_results.json", "w") as f:
+        json.dump(results, f, indent=2)
+    print("Results saved to results/mnist_pv_results.json")
+
+    # Generate comparison plots
+    print("\nGenerating comparison plots...")
+    plot_comparison(results, "results/mnist_pv_comparison.png")
+
+    # Print summary table
+    print_summary_table(results)
+
+    print("\n" + "=" * 60)
+    print("Benchmark complete!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/api-reference/manifolds.md
+++ b/docs/api-reference/manifolds.md
@@ -4,11 +4,12 @@ This page documents the core manifold operations in Hyperbolix. Each manifold is
 
 ## Overview
 
-Hyperbolix provides three manifold classes:
+Hyperbolix provides four manifold classes:
 
 - **Euclidean**: Flat Euclidean space (baseline)
 - **Poincaré Ball**: Conformal model of hyperbolic space
 - **Hyperboloid**: Lorentz/Minkowski model of hyperbolic space
+- **Proper Velocity**: Unconstrained $\mathbb{R}^n$ model from special relativity (Chen et al. 2026)
 
 All manifolds share a common interface defined by the `Manifold` protocol and support:
 
@@ -64,6 +65,27 @@ The hyperboloid (Lorentz) model with Minkowski geometry.
     - `hcat`: Lorentz direct concatenation for convolutions
 
 ::: hyperbolix.manifolds.hyperboloid.Hyperboloid
+    options:
+      show_source: true
+      heading_level: 3
+
+## Proper Velocity
+
+The Proper Velocity (PV) model — an **unconstrained** $\mathbb{R}^n$ representation of hyperbolic geometry rooted in special relativity's proper velocity (Ungar 2022, Ch. 10). PV is algebraically a gyrovector space isomorphic to the Poincaré ball via $\pi(x) = (\beta_x / (1 + \beta_x)) \cdot x$, and carries a Riemannian metric making that isomorphism an isometry.
+
+!!! note "Why Proper Velocity?"
+    Unlike the bounded Poincaré ball (points must stay in the open unit ball) and the constrained hyperboloid (points must satisfy $\langle x, x \rangle_L = -1/c$), PV points live in all of $\mathbb{R}^n$ with no constraint. This gives:
+
+    - **No projection step** after updates — the manifold *is* $\mathbb{R}^n$
+    - **Better numerical stability** for large radii (no boundary collapse, no Lorentz constraint drift)
+    - **Drop-in with Euclidean optimizers** — the retraction reduces to $x + v$
+
+    The metric $g_x(u,v) = \langle u, v\rangle - c\beta_x^2\langle x,u\rangle\langle x,v\rangle$ still gives sectional curvature $-c$; only the coordinates change.
+
+!!! info "Convention"
+    The paper uses curvature $K < 0$ with $\beta_x = 1/\sqrt{1 - K\|x\|^2}$. Hyperbolix keeps the $c > 0$ convention (sectional curvature $-c$), substituting $K = -c$, so $\beta_x = 1/\sqrt{1 + c\|x\|^2}$.
+
+::: hyperbolix.manifolds.proper_velocity.ProperVelocity
     options:
       show_source: true
       heading_level: 3
@@ -149,6 +171,37 @@ y = poincare.expmap(v, x, c=1.0)
 
 # Logarithmic map (inverse operation)
 v_recovered = poincare.logmap(y, x, c=1.0)
+```
+
+### Proper Velocity Operations
+
+```python
+import jax
+import jax.numpy as jnp
+from hyperbolix.manifolds import ProperVelocity
+
+pv = ProperVelocity()
+c = 1.0
+
+# Points live in unconstrained R^n — no projection step needed
+x = jnp.array([0.3, 0.5])
+y = jnp.array([-0.2, 0.4])
+
+# Geodesic distance (asinh form — stable over all of R^n)
+d = pv.dist(x, y, c)
+
+# Exp/log maps at the origin
+v = jnp.array([0.1, -0.2])
+y_moved = pv.expmap_0(v, c)
+v_recovered = pv.logmap_0(y_moved, c)
+
+# Euclidean gradient -> Riemannian gradient under the PV metric
+grad_euc = jnp.array([1.0, 0.0])
+grad_riem = pv.egrad2rgrad(grad_euc, x, c)
+
+# Retraction is exact Euclidean addition (PV is unconstrained)
+x_next = pv.retraction(v, x, c)
+assert jnp.allclose(x_next, x + v)
 ```
 
 ### Isometry Mappings

--- a/docs/api-reference/nn-layers.md
+++ b/docs/api-reference/nn-layers.md
@@ -6,14 +6,15 @@ Hyperbolic neural network layers built with Flax NNX.
 
 Hyperbolix provides 20+ neural network layer classes and 5 activation functions for building hyperbolic deep learning models:
 
-- **Linear Layers**: Poincaré and Hyperboloid linear transformations, including FGG (Fast and Geometrically Grounded) layers
-- **Convolutional Layers**: HCat-based, HRC-based, and FGG hyperbolic convolutions
+- **Linear Layers**: Poincaré, Hyperboloid, and Proper Velocity linear transformations, including FGG (Fast and Geometrically Grounded) layers
+- **Convolutional Layers**: HCat-based, HRC-based, FGG, and Proper Velocity hyperbolic convolutions
 - **Normalization**: Poincaré batch normalization (`PoincareBatchNorm2D`), HRC-wrapped norms, and FGG mean-only batch norm
 - **Hypformer Components**: HTC (Hyperbolic Transformation Component) and HRC (Hyperbolic Regularization Component) with curvature-change support
 - **FGG Components**: `FGGLinear`, `FGGConv2D`, `FGGMeanOnlyBatchNorm` from Klis et al. (2026) — linear-distance growth, ~3× faster than prior work
+- **Proper Velocity Components**: `HypLinearPV`, `HypConv2DPV`, `HypRegressionPV` from Chen et al. (2026) — unconstrained $\mathbb{R}^n$ geometry with exact Euclidean retraction
 - **Attention Layers**: Three hyperbolic attention variants (linear O(N), softmax O(N²), full Lorentzian O(N²)) from the Hypformer paper
 - **Positional Encoding**: HOPE (Hyperbolic Rotary PE) and Hypformer learnable positional encodings for Transformers
-- **Regression Layers**: Single-layer classifiers with Riemannian geometry, including `FGGLorentzMLR`
+- **Regression Layers**: Single-layer classifiers with Riemannian geometry, including `FGGLorentzMLR` and `HypRegressionPV`
 - **Activation Functions**: Hyperbolic ReLU, Leaky ReLU, Tanh, Swish, GELU
 - **Helper Functions**: Utilities for regression and conformal factor computation
 
@@ -53,6 +54,15 @@ All layers follow Flax NNX conventions and store manifold module references.
 ### FGG Linear (Klis et al. 2026)
 
 ::: hyperbolix.nn_layers.FGGLinear
+    options:
+      show_source: true
+      heading_level: 4
+
+### Proper Velocity Linear (Chen et al. 2026)
+
+`HypLinearPV` implements the PV fully-connected layer from Chen et al. 2026 (Thm 5.3 / Eq. 22): $y_k = (1/\sqrt{c}) \cdot \sinh(\sqrt{c} \cdot v_k(x))$ where $v_k(x)$ is the PV multinomial-logistic-regression signed margin. Because PV is an unconstrained $\mathbb{R}^n$ model, inputs and outputs live in Euclidean space with no projection step.
+
+::: hyperbolix.nn_layers.HypLinearPV
     options:
       show_source: true
       heading_level: 4
@@ -258,6 +268,23 @@ h_eval = jax.nn.relu(h_eval)
 | **Distance growth** | Linear | Logarithmic | Logarithmic |
 | **Default padding** | Manifold origin | Edge replication | Edge replication |
 | **Weight norm** | Optional (`use_weight_norm`) | No | No |
+
+### Proper Velocity Convolution (Chen et al. 2026)
+
+`HypConv2DPV` implements the PV 2D convolution from Chen et al. 2026 (Sec 5.3). Because PV's geometry is unconstrained ($\mathbb{R}^n$), patch concatenation coincides with Euclidean concatenation — **no beta-scaling step is required** (unlike `HypConv2DPoincare`). Outputs live on the PV manifold, so activations can be applied directly between conv layers without expmap/logmap round-trips.
+
+::: hyperbolix.nn_layers.HypConv2DPV
+    options:
+      show_source: true
+      heading_level: 4
+
+| Feature | HypConv2DPV | HypConv2DPoincare | HypConv2DHyperboloid |
+|---------|-------------|-------------------|----------------------|
+| **Model** | Proper Velocity ($\mathbb{R}^n$) | Poincaré ball | Hyperboloid |
+| **Aggregation** | Raw Euclidean concat | Beta-concatenation | HCat (Lorentz concat) |
+| **Dimension** | Preserved | Preserved | Grows: $(d-1) K^2 + 1$ |
+| **Default input** | Manifold | Tangent space | Manifold (ambient) |
+| **Output** | PV manifold | Tangent space | Hyperboloid (ambient) |
 
 ### LorentzConv2D (HRC-Based)
 
@@ -847,6 +874,68 @@ Single-layer classifiers with Riemannian geometry.
       show_source: true
       heading_level: 4
 
+### Proper Velocity Regression (Chen et al. 2026)
+
+`HypRegressionPV` implements the PV multinomial-logistic-regression layer (Thm 5.2 / Eq. 19). The output is the Euclidean signed margin to each PV hyperplane, intended for a standard softmax-cross-entropy loss.
+
+::: hyperbolix.nn_layers.HypRegressionPV
+    options:
+      show_source: true
+      heading_level: 4
+
+#### PV Usage Example
+
+```python
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from hyperbolix.manifolds import ProperVelocity
+from hyperbolix.nn_layers import HypConv2DPV, HypLinearPV, HypRegressionPV
+
+pv = ProperVelocity()
+rngs = nnx.Rngs(0)
+c = 1.0
+
+# --- HypConv2DPV: dimension-preserving hyperbolic convolution ---
+conv = HypConv2DPV(
+    manifold_module=pv,
+    in_channels=16,
+    out_channels=32,
+    kernel_size=3,
+    rngs=rngs,
+    input_space="tangent",  # lift Euclidean features via expmap_0
+)
+x = jax.random.normal(jax.random.PRNGKey(1), (8, 28, 28, 16)) * 0.1
+h = conv(x, c=c)
+print(h.shape)  # (8, 28, 28, 32) — on the PV manifold
+
+# --- HypLinearPV: fully-connected PV layer ---
+linear = HypLinearPV(
+    manifold_module=pv,
+    in_dim=32,
+    out_dim=64,
+    rngs=rngs,
+)
+h_flat = h.reshape(-1, 32)
+h_fc = linear(h_flat, c=c)
+print(h_fc.shape)  # (8*28*28, 64)
+
+# --- HypRegressionPV: classification head (Euclidean logits) ---
+mlr = HypRegressionPV(
+    manifold_module=pv,
+    in_dim=64,
+    out_dim=10,
+    rngs=rngs,
+)
+logits = mlr(h_fc, c=c)
+print(logits.shape)  # (8*28*28, 10) — feed to softmax cross-entropy
+```
+
+!!! tip "When to Use Proper Velocity"
+    - **Large-radius features** — the unbounded $\mathbb{R}^n$ coordinates avoid both the Poincaré boundary ($\lambda \to 0$) and hyperboloid constraint drift.
+    - **Standard Euclidean optimizers** — the retraction is exact Euclidean addition, so Adam/SGD on PV parameters needs no Riemannian wrapper.
+    - **Simple conv stacks** — raw Euclidean concat replaces beta-scaling/HCat, and no dimension growth per layer.
+
 ### FGG Usage Example
 
 ```python
@@ -1148,6 +1237,7 @@ The neural network layers implement methods from:
 - **Hypformer (Yang et al. 2025)**: "Hyperbolic Transformers" - HTC/HRC components with curvature-change support
 - **Chen et al. (2024)**: "Hyperbolic Embeddings for Learning on Manifolds (HELM)" - HOPE positional encoding and Lorentzian residual connections
 - **Klis et al. (2026)**: "Fast and Geometrically Grounded Lorentz Neural Networks" - `FGGLinear`, `FGGConv2D`, `FGGLorentzMLR`, `FGGMeanOnlyBatchNorm`; sinh/arcsinh cancellation for linear hyperbolic distance growth
+- **Chen et al. (2026)**: "Proper Velocity Neural Networks" - `HypLinearPV`, `HypConv2DPV`, `HypRegressionPV`; unconstrained $\mathbb{R}^n$ model of hyperbolic geometry with exact Euclidean retraction
 
 ### Key Theoretical Connections
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,11 @@ All notable changes to Hyperbolix will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Proper Velocity (PV) manifold** (`hyperbolix.manifolds.ProperVelocity`) — unconstrained $\mathbb{R}^n$ model of hyperbolic geometry from Chen et al. (2026), with complete geometric operations: `addition`, `scalar_mul`, `dist`, `expmap`/`logmap` (at origin and arbitrary base points), `ptransp`/`ptransp_0`, `egrad2rgrad`, and Riemannian inner product
+- **Proper Velocity neural-network layers**:
+    - `HypLinearPV`: PV fully-connected layer (Thm 5.3 / Eq. 22)
+    - `HypConv2DPV`: PV 2D convolution with raw Euclidean patch concatenation (Sec 5.3) — no beta-scaling, dimension-preserving
+    - `HypRegressionPV`: PV multinomial-logistic-regression head (Thm 5.2 / Eq. 19)
 - MkDocs Material documentation system
 - Complete API reference documentation
 - Getting Started guide

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,11 +75,12 @@ print(f"Distances shape: {distances.shape}")  # (100,)
 
 ### Manifolds
 
-Hyperbolix provides three manifold types:
+Hyperbolix provides four manifold types:
 
 - **Euclidean**: Flat space (baseline)
 - **Poincaré Ball**: Conformal model (angles preserved)
 - **Hyperboloid**: Lorentz model (natural for convolutions)
+- **Proper Velocity**: Unconstrained $\mathbb{R}^n$ model from special relativity (Chen et al. 2026) — no projection step, Euclidean retraction
 
 ### Curvature Parameter
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ Hyperbolix is a pure JAX implementation of hyperbolic deep learning, providing m
 
 ## Features
 
-- **3 Manifolds**: Euclidean, Poincaré Ball, and Hyperboloid with complete geometric operations
-- **Neural Network Layers**: 13+ hyperbolic layers including linear, convolutional, and regression layers
+- **4 Manifolds**: Euclidean, Poincaré Ball, Hyperboloid, and Proper Velocity with complete geometric operations
+- **Neural Network Layers**: 20+ hyperbolic layers including linear, convolutional, regression, attention, and PV layers
 - **Activation Functions**: 4 hyperbolic activations (ReLU, Leaky ReLU, Tanh, Swish)
 - **Riemannian Optimizers**: RAdam and RSGD with automatic manifold parameter detection
 - **Wrapped Normal Distributions**: For probabilistic modeling on hyperbolic manifolds

--- a/docs/user-guide/numerical-stability.md
+++ b/docs/user-guide/numerical-stability.md
@@ -175,6 +175,53 @@ poincare_f64 = Poincare(dtype=jnp.float64)
 dist_precise = poincare_f64.dist(x, y, c=1.0)  # returns float64
 ```
 
+## Proper Velocity: An Unconstrained Alternative
+
+The Proper Velocity (PV) model (Chen et al. 2026) sidesteps the conformal-factor and boundary problems above by representing hyperbolic geometry in **unconstrained $\mathbb{R}^n$**. Points carry no norm constraint, so there is no boundary to drift toward and no $\lambda(x) \to \infty$ singularity.
+
+Use `ProperVelocity` when your features or embeddings reach large geodesic distances from the origin and float32 precision must be preserved.
+
+### Why PV Stays Stable at Large Radii
+
+| Issue (Poincaré / Hyperboloid) | PV behavior |
+|--------------------------------|-------------|
+| $\lambda(x) = 2/(1 - c\|x\|^2) \to \infty$ near boundary | $\beta_x = 1/\sqrt{1 + c\|x\|^2}$, bounded in $(0, 1]$, smooth everywhere |
+| Catastrophic cancellation in $1 - c\|x\|^2$ | No boundary; $1 + c\|x\|^2$ grows monotonically |
+| Hyperboloid constraint drift after Euclidean update | PV is $\mathbb{R}^n$ — any finite vector is a valid point |
+| `atanh` clamp required at the boundary | Geodesic distance uses `asinh`, stable on all of $\mathbb{R}$ |
+
+The PV distance formula
+$$
+d(0, x) = \frac{1}{\sqrt{c}} \cdot \mathrm{asinh}(\sqrt{c}\,\|x\|)
+$$
+remains finite and accurate in float32 for $\|x\|$ up to at least $10^2$ — covered by `test_pv_stability_at_large_norms` in the test suite.
+
+### Example
+
+```python
+import jax
+import jax.numpy as jnp
+from hyperbolix.manifolds import ProperVelocity
+
+pv = ProperVelocity()
+c = 1.0
+
+# PV tolerates large-norm inputs where Poincaré would hit the boundary.
+x_large = jnp.array([50.0, 0.0, 0.0])
+d = pv.dist_0(x_large, c)      # ~ 4.61 — finite, accurate
+y = pv.logmap_0(x_large, c)    # finite tangent vector
+x_rec = pv.expmap_0(y, c)      # round-trips to x_large
+```
+
+### Choosing a Manifold for Stability
+
+- **Poincaré ball**: compact, bounded — fine for small distances ($<5$) and visualization; clamp or use float64 past that.
+- **Hyperboloid**: unbounded radius, but the constraint $\langle x, x\rangle_L = -1/c$ must be maintained and can drift under Euclidean updates.
+- **Proper Velocity**: unconstrained $\mathbb{R}^n$, stable at large radii, exact Euclidean retraction (plain `optax.adam` / SGD trains PV layers without a Riemannian wrapper). Preferred when embeddings naturally grow large.
+
+!!! note "Training PV layers"
+    `HypLinearPV`, `HypConv2DPV`, and `HypRegressionPV` store their weights as plain `nnx.Param` (not `ManifoldParam`). Use a standard `nnx.Optimizer(model, optax.adam(lr), wrt=nnx.Param)` — no `riemannian_adam` / `riemannian_sgd` wrapper is required.
+
 ## Hyperbolic Function Overflow
 
 ### The Problem
@@ -498,6 +545,7 @@ def validate_batch(x_batch, c=1.0, atol=1e-5):
     - ✅ **Use `VERSION_MOBIUS_DIRECT` for Poincaré distance** unless issues arise
     - ✅ **Clip curvature** if learnable (0.01 < c < 10.0)
     - ✅ **Initialize embeddings conservatively** (small norms)
+    - ✅ **Prefer `ProperVelocity` for large-radius features** — unconstrained $\mathbb{R}^n$ avoids the boundary entirely and trains with plain `optax.adam`
 
 ## Debugging Numerical Issues
 

--- a/hyperbolix/manifolds/__init__.py
+++ b/hyperbolix/manifolds/__init__.py
@@ -6,6 +6,7 @@ from . import isometry_mappings
 from .euclidean import Euclidean
 from .hyperboloid import Hyperboloid
 from .poincare import Poincare
+from .proper_velocity import ProperVelocity
 from .protocol import Manifold
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "Hyperboloid",
     "Manifold",
     "Poincare",
+    "ProperVelocity",
     "isometry_mappings",
 ]

--- a/hyperbolix/manifolds/proper_velocity.py
+++ b/hyperbolix/manifolds/proper_velocity.py
@@ -1,0 +1,658 @@
+"""Proper Velocity (PV) manifold - class-based API with dtype control.
+
+JAX port with vmap-native API. All functions operate on single points/vectors
+in R^n. Use jax.vmap for batch operations.
+
+Convention
+----------
+Paper (Chen et al. 2026) uses curvature ``K < 0`` with
+``β_x = 1/√(1 - K·||x||²)``. We keep hyperbolix's ``c > 0`` convention
+(sectional curvature ``-c``), substituting ``K = -c``. All formulas below
+are expressed in the ``c > 0`` form:
+
+- PV beta factor: ``β_x = 1/√(1 + c·||x||²)``
+- Riemannian metric: ``g_x(u, v) = ⟨u, v⟩ - c·β_x²·⟨x, u⟩·⟨x, v⟩``
+- Origin: the zero vector ``0 ∈ R^n`` (PV has no time coordinate; unlike
+  the Hyperboloid model, points are not constrained).
+
+The PV space is an **unconstrained** ``R^n`` model of hyperbolic geometry
+rooted in special relativity's proper velocity. It is algebraically a
+gyrovector space (isomorphic to the Poincaré ball via
+``π(x) = (β_x / (1 + β_x)) · x``) and carries a Riemannian metric that
+makes that isomorphism an isometry.
+
+JIT Compilation & Batching
+---------------------------
+All functions work on single points and return scalars or vectors.
+Use jax.vmap for batching and jax.jit for compilation:
+
+    >>> import jax
+    >>> import jax.numpy as jnp
+    >>> from hyperbolix.manifolds.proper_velocity import ProperVelocity
+    >>>
+    >>> manifold = ProperVelocity(dtype=jnp.float32)
+    >>> x = jnp.array([0.1, 0.2])
+    >>> y = jnp.array([0.3, 0.4])
+    >>> d = manifold.dist(x, y, c=1.0)
+    >>>
+    >>> # Batch operations via vmap
+    >>> x_batch = jnp.array([[0.1, 0.2], [0.15, 0.25]])
+    >>> dist_batched = jax.vmap(manifold.dist, in_axes=(0, 0, None))
+    >>> distances = dist_batched(x_batch, jnp.roll(x_batch, 1, axis=0), 1.0)
+
+References
+----------
+Chen et al. "Proper Velocity Neural Networks." ICLR 2026.
+Ungar. "A Gyrovector Space Approach to Hyperbolic Geometry." 2022.
+"""
+
+import math
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+from ..utils.math_utils import cosh, sinh, smooth_clamp
+from ._base import ManifoldBase
+
+# Default numerical parameters
+MIN_NORM = 1e-15
+
+# Version selection constant. PV currently has a single canonical implementation,
+# kept for API consistency with Poincare / Hyperboloid.
+VERSION_DEFAULT = 0
+
+
+# ---------------------------------------------------------------------------
+# Core helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_origin(c: Float[Array, ""] | float, dim: int, dtype=jnp.float32) -> Float[Array, "dim"]:
+    """Create PV origin: the zero vector in R^n."""
+    del c  # curvature is irrelevant: the PV origin is always 0.
+    return jnp.zeros(dim, dtype=dtype)
+
+
+def _beta(x: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, ""]:
+    """PV beta factor β_x = 1/√(1 + c·||x||²)."""
+    x_sqnorm = jnp.dot(x, x)
+    return 1.0 / jnp.sqrt(1.0 + c * x_sqnorm)
+
+
+def _beta_inv(x: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, ""]:
+    """Reciprocal of the PV beta factor: 1/β_x = √(1 + c·||x||²)."""
+    x_sqnorm = jnp.dot(x, x)
+    return jnp.sqrt(1.0 + c * x_sqnorm)
+
+
+def _safe_norm(x: Float[Array, "dim"]) -> Float[Array, ""]:
+    """Numerically safe Euclidean norm √(||x||² + MIN_NORM²) with smooth gradient at x=0."""
+    return jnp.sqrt(jnp.sum(x**2) + MIN_NORM**2)
+
+
+def _dpi_x(x: Float[Array, "dim"], v: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """Differential of π: PV → Poincaré (paper Eq. 7 with K = -c).
+
+    dπ_x(v) = β_x/(1+β_x)·v - c·β_x³/(1+β_x)²·⟨x, v⟩·x
+    """
+    beta_x = _beta(x, c)
+    xv = jnp.dot(x, v)
+    one_plus_beta = 1.0 + beta_x
+    term1 = (beta_x / one_plus_beta) * v
+    term2 = (c * beta_x**3 / one_plus_beta**2) * xv * x
+    return term1 - term2
+
+
+def _mobius_gyration(
+    a: Float[Array, "dim"],
+    b: Float[Array, "dim"],
+    z: Float[Array, "dim"],
+    c: Float[Array, ""] | float,
+) -> Float[Array, "dim"]:
+    """Möbius gyration gyr_M[a, b]z on the Poincaré ball (self-contained copy).
+
+    Same formula as ``poincare._gyration`` but inlined here so the PV module
+    does not depend on the Poincaré implementation.
+    """
+    c2 = c**2
+    a_sqnorm = jnp.dot(a, a)
+    b_sqnorm = jnp.dot(b, b)
+    ab = jnp.dot(a, b)
+    az = jnp.dot(a, z)
+    bz = jnp.dot(b, z)
+
+    coef_a = -c2 * az * b_sqnorm + c * bz + 2 * c2 * ab * bz
+    coef_b = -c2 * bz * a_sqnorm - c * az
+    num = 2 * (coef_a * a + coef_b * b)
+    denom = jnp.maximum(1 + 2 * c * ab + c2 * a_sqnorm * b_sqnorm, MIN_NORM)
+    return z + num / denom
+
+
+# ---------------------------------------------------------------------------
+# PV gyro-operations
+# ---------------------------------------------------------------------------
+
+
+def _addition(x: Float[Array, "dim"], y: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """PV gyroaddition x ⊕_U y (paper Eq. 2 with K = -c).
+
+    x ⊕ y = x + y + {(1 - β_y)/β_y + c·β_x/(1+β_x)·⟨x, y⟩}·x
+    """
+    beta_x = _beta(x, c)
+    xy = jnp.dot(x, y)
+
+    # Numerically robust form for (1 - β_y)/β_y = 1/β_y - 1 = √(1+c||y||²) - 1.
+    # This avoids catastrophic cancellation for ||y|| ≈ 0.
+    beta_y_inv_minus_one = _beta_inv(y, c) - 1.0
+    coef = beta_y_inv_minus_one + c * beta_x / (1.0 + beta_x) * xy
+    return x + y + coef * x
+
+
+def _scalar_mul(t: Float[Array, ""] | float, x: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """PV scalar multiplication t ⊗_U x (paper Eq. 3 with K = -c).
+
+    t ⊗ x = sinh(t · asinh(√c·||x||)) · x / (√c·||x||),     t ⊗ 0 = 0
+    """
+    sqrt_c = jnp.sqrt(c)
+    x_norm = _safe_norm(x)
+    arg = sqrt_c * x_norm  # √c·||x||, never exactly zero
+    # sinh is the overflow-protected variant; jnp.asinh is stable on all of R.
+    scale = sinh(t * jnp.asinh(arg)) / arg
+    return scale * x
+
+
+# ---------------------------------------------------------------------------
+# Distance
+# ---------------------------------------------------------------------------
+
+
+def _dist(x: Float[Array, "dim"], y: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, ""]:
+    """Geodesic distance d(x, y) on PV (paper Eq. 13, asinh form).
+
+    The atanh form ``(2/√c)·atanh(√c·||π(-x⊕y)||)`` is algebraically equal to
+    ``(1/√c)·asinh(√c·||-x⊕y||)`` (both follow from the tanh/sinh half-angle
+    identities). We use the asinh form because jnp.asinh is stable over all
+    of R while atanh requires boundary clamping.
+    """
+    sqrt_c = jnp.sqrt(c)
+    z = _addition(-x, y, c)
+    z_norm = jnp.linalg.norm(z)
+    return jnp.asinh(sqrt_c * z_norm) / sqrt_c
+
+
+def _dist_0(x: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, ""]:
+    """Geodesic distance from the PV origin (paper Thm 4.3 simplified).
+
+    d(0, x) = (1/√c) · asinh(√c · ||x||)
+    """
+    sqrt_c = jnp.sqrt(c)
+    x_norm = jnp.linalg.norm(x)
+    return jnp.asinh(sqrt_c * x_norm) / sqrt_c
+
+
+# ---------------------------------------------------------------------------
+# Exp / log maps
+# ---------------------------------------------------------------------------
+
+
+def _expmap_0(v: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """Exponential map from the origin (paper Thm 4.3 simplified).
+
+    exp_0(v) = sinh(√c·||v||) · v / (√c·||v||)
+
+    Written via sinh/arg with a safe-norm substitution so the v=0 case gives 0.
+    """
+    sqrt_c = jnp.sqrt(c)
+    v_norm = _safe_norm(v)
+    arg = sqrt_c * v_norm
+    # sinh(arg)/arg has limit 1 as arg → 0, which the safe_norm preserves.
+    scale = sinh(arg) / arg
+    return scale * v
+
+
+def _logmap_0(y: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """Logarithmic map to the origin (paper Thm 4.3 simplified).
+
+    log_0(y) = asinh(√c·||y||) · y / (√c·||y||)
+    """
+    sqrt_c = jnp.sqrt(c)
+    y_norm = _safe_norm(y)
+    arg = sqrt_c * y_norm
+    # asinh(arg)/arg has limit 1 as arg → 0.
+    scale = jnp.asinh(arg) / arg
+    return scale * y
+
+
+def _expmap(v: Float[Array, "dim"], x: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """Exponential map at x (paper Eq. 10 with K = -c).
+
+    Uses the simplified form
+
+        exp_x(v) = x ⊕ ((1+β_x)/β_x · sinhc(√c·√g_x(v,v)) · dπ_x(v))
+
+    with sinhc(t) = sinh(t)/t. This exploits the identity
+    ``(1+β_x)/β_x · ||dπ_x(v)|| = √g_x(v, v)`` (proved by expanding both sides
+    against the Riemannian metric), which avoids dividing by ||dπ_x(v)||
+    — potentially tiny — and keeps the result well-defined at v = 0.
+    """
+    sqrt_c = jnp.sqrt(c)
+    beta_x = _beta(x, c)
+
+    dpi_v = _dpi_x(x, v, c)
+
+    # g_x(v, v) = ⟨v, v⟩ - c·β_x²·⟨x, v⟩²
+    xv = jnp.dot(x, v)
+    g_vv = jnp.dot(v, v) - c * beta_x**2 * xv**2
+    g_vv_safe = jnp.maximum(g_vv, 0.0) + MIN_NORM**2
+    g_norm = jnp.sqrt(g_vv_safe)
+    arg = sqrt_c * g_norm
+
+    # sinhc(arg) = sinh(arg)/arg; the safe norm guarantees arg > 0.
+    sinhc = sinh(arg) / arg
+
+    coef = (1.0 + beta_x) / beta_x * sinhc
+    return _addition(x, coef * dpi_v, c)
+
+
+def _logmap(y: Float[Array, "dim"], x: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """Logarithmic map at x (paper Eq. 11 with K = -c).
+
+    Uses the simplified form
+
+        log_x(y) = asinhc(√c·||z||) · (z + (β_x·c / (1+β_x)) · ⟨x, z⟩ · x)
+
+    with z = -x ⊕ y and asinhc(t) = asinh(t)/t. This follows from the
+    identity ``2·atanh(√c·||π(z)||) = asinh(√c·||z||)`` (tanh/sinh half-angle
+    identity applied to ``β_z/(1+β_z)·√c·||z||``), which collapses the paper's
+    sigma, tau coefficients into a single scalar scaling applied after a vector
+    combination. Avoids explicitly computing π(z).
+    """
+    sqrt_c = jnp.sqrt(c)
+    beta_x = _beta(x, c)
+
+    z = _addition(-x, y, c)
+    xz = jnp.dot(x, z)
+    z_norm = _safe_norm(z)
+    arg = sqrt_c * z_norm
+
+    # asinhc(arg) = asinh(arg)/arg, limit 1 as arg → 0.
+    asinhc = jnp.asinh(arg) / arg
+
+    coef_x = beta_x * c / (1.0 + beta_x)
+    direction = z + coef_x * xz * x
+    return asinhc * direction
+
+
+def _retraction(v: Float[Array, "dim"], x: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """Euclidean retraction x + v. PV is unconstrained, so this is exact.
+
+    Kept separate from expmap to match the other manifolds' APIs; use ``expmap``
+    for the exact Riemannian map.
+    """
+    del c  # PV is unconstrained -- no projection needed.
+    return x + v
+
+
+# ---------------------------------------------------------------------------
+# Parallel transport
+# ---------------------------------------------------------------------------
+
+
+def _ptransp_0(v: Float[Array, "dim"], y: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """Parallel transport from the origin to y (paper Thm 4.3, K = -c).
+
+    PT_{0→y}(v) = v + c·β_y/(1+β_y) · ⟨y, v⟩ · y
+    """
+    beta_y = _beta(y, c)
+    yv = jnp.dot(y, v)
+    coef = c * beta_y / (1.0 + beta_y)
+    return v + coef * yv * y
+
+
+def _ptransp(
+    v: Float[Array, "dim"],
+    x: Float[Array, "dim"],
+    y: Float[Array, "dim"],
+    c: Float[Array, ""] | float,
+) -> Float[Array, "dim"]:
+    """Parallel transport from T_x PV to T_y PV (paper Eq. 12 with K = -c).
+
+    PT_{x→y}(v) = (1+β_x)/β_x · ṽ + c·(1+β_x)·β_y/((1+β_y)·β_x) · ⟨y, ṽ⟩ · y
+
+    where ṽ = gyr_M[ȳ, -x̄](dπ_x(v)) is the Möbius gyration in the Poincaré
+    ball acting on dπ_x(v), with x̄ = β_x/(1+β_x)·x and ȳ = β_y/(1+β_y)·y.
+    """
+    beta_x = _beta(x, c)
+    beta_y = _beta(y, c)
+
+    # Poincaré-ball images of x and y under π.
+    x_bar = (beta_x / (1.0 + beta_x)) * x
+    y_bar = (beta_y / (1.0 + beta_y)) * y
+
+    # Differential of π at x applied to v.
+    dpi_v = _dpi_x(x, v, c)
+
+    # Möbius gyration in the Poincaré ball.
+    v_tilde = _mobius_gyration(y_bar, -x_bar, dpi_v, c)
+
+    # Eq. 12 (K = -c flips the sign of the second term).
+    yv = jnp.dot(y, v_tilde)
+    coef1 = (1.0 + beta_x) / beta_x
+    coef2 = c * (1.0 + beta_x) * beta_y / ((1.0 + beta_y) * beta_x)
+    return coef1 * v_tilde + coef2 * yv * y
+
+
+# ---------------------------------------------------------------------------
+# Tangent space
+# ---------------------------------------------------------------------------
+
+
+def _tangent_inner(
+    u: Float[Array, "dim"],
+    v: Float[Array, "dim"],
+    x: Float[Array, "dim"],
+    c: Float[Array, ""] | float,
+) -> Float[Array, ""]:
+    """Riemannian inner product ⟨u, v⟩_x (paper Eq. 1 with K = -c).
+
+    g_x(u, v) = ⟨u, v⟩ - c·β_x²·⟨x, u⟩·⟨x, v⟩
+    """
+    beta_x = _beta(x, c)
+    uv = jnp.dot(u, v)
+    xu = jnp.dot(x, u)
+    xv = jnp.dot(x, v)
+    return uv - c * beta_x**2 * xu * xv
+
+
+def _tangent_norm(v: Float[Array, "dim"], x: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, ""]:
+    """Riemannian norm ||v||_x = √g_x(v, v)."""
+    inner = _tangent_inner(v, v, x, c)
+    return jnp.sqrt(jnp.maximum(inner, 0.0))
+
+
+def _tangent_proj(v: Float[Array, "dim"], x: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """Tangent-space projection. T_x PV = R^n, so the projection is identity."""
+    del x, c
+    return v
+
+
+def _egrad2rgrad(grad: Float[Array, "dim"], x: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """Convert Euclidean gradient to Riemannian gradient under the PV metric.
+
+    From g_x(u, v) = ⟨u, A(x) v⟩ with A(x) = I - c·β_x²·x xᵀ, the Riemannian
+    gradient satisfies A(x) rgrad = grad. Sherman-Morrison gives
+    A(x)⁻¹ = I + c·x xᵀ (the 1 - c·β_x²·||x||² factor cancels with β_x²), so
+
+        rgrad = grad + c · ⟨x, grad⟩ · x.
+    """
+    xg = jnp.dot(x, grad)
+    return grad + c * xg * x
+
+
+# ---------------------------------------------------------------------------
+# Projection & validation
+# ---------------------------------------------------------------------------
+
+
+def _proj(x: Float[Array, "dim"], c: Float[Array, ""] | float) -> Float[Array, "dim"]:
+    """Projection onto PV. PV is R^n; we only replace non-finite entries."""
+    del c
+    return jnp.nan_to_num(x)
+
+
+def _is_in_manifold(x: Float[Array, "dim"], c: Float[Array, ""] | float, atol: float = 1e-5) -> Array:
+    """Every finite point in R^n lies on the PV manifold."""
+    del c, atol
+    return jnp.all(jnp.isfinite(x))
+
+
+def _is_in_tangent_space(
+    v: Float[Array, "dim"],
+    x: Float[Array, "dim"],
+    c: Float[Array, ""] | float,
+    atol: float | None = None,
+) -> Array:
+    """Every finite vector in R^n is a tangent vector at any PV point."""
+    del x, c, atol
+    return jnp.all(jnp.isfinite(v))
+
+
+def _embed_spatial_0(v_spatial: Float[Array, "... n"]) -> Float[Array, "... n"]:
+    """Identity embedding for PV: no time coord to prepend (kept for API parity)."""
+    return v_spatial
+
+
+# ---------------------------------------------------------------------------
+# Batch-compatible helpers (used by NN layers)
+# ---------------------------------------------------------------------------
+
+
+def _compute_mlr(
+    x: Float[Array, "batch in_dim"],
+    z: Float[Array, "out_dim in_dim"],
+    r: Float[Array, "out_dim 1"],
+    c: Float[Array, ""] | float,
+    clamping_factor: float,
+    smoothing_factor: float,
+    min_enorm: float = 1e-15,
+) -> Float[Array, "batch out_dim"]:
+    """PV multinomial logistic regression (paper Thm 5.2, Eq. 19 with K = -c).
+
+    For each class k with parameters ``(z_k, r_k)`` the signed margin to the
+    PV hyperplane is
+
+        v_k(x) = (||z_k|| / √c) · asinh(
+                    cosh(√c·r_k) · √c/||z_k|| · ⟨x, z_k⟩
+                    - sinh(√c·r_k) · √(1 + c·||x||²)
+                 )
+
+    The asinh argument is smoothly clamped to ``±clamping_factor · log(2/eps)``
+    for numerical stability, matching the convention used by the Poincaré and
+    Hyperboloid MLR helpers.
+
+    Args:
+        x: PV points, shape (batch, in_dim).
+        z: Per-class spatial directions, shape (out_dim, in_dim).
+        r: Per-class scalar offsets, shape (out_dim, 1).
+        c: Curvature (positive).
+        clamping_factor: Scales the dtype-dependent clamp bound.
+        smoothing_factor: Softness of the smooth clamp transition.
+        min_enorm: Lower bound added under the sqrt when normalizing z.
+
+    Returns:
+        MLR scores, shape (batch, out_dim).
+    """
+    sqrt_c = jnp.sqrt(c)
+    sr_1P = sqrt_c * r.T  # (1, P)
+
+    # Safe norm on z so that z=0 rows do not create NaNs.
+    z_norm_P1 = jnp.sqrt(jnp.sum(z**2, axis=-1, keepdims=True) + min_enorm**2)  # (P, 1)
+
+    beta_inv_x_B1 = jnp.sqrt(1.0 + c * jnp.sum(x**2, axis=-1, keepdims=True))  # (B, 1)
+
+    xz_BP = jnp.einsum("bi,oi->bo", x, z)  # (B, P)
+
+    # Eq. 19 asinh argument, in (B, P).
+    term_A_BP = cosh(sr_1P) * (sqrt_c / z_norm_P1.T) * xz_BP
+    term_B_BP = sinh(sr_1P) * beta_inv_x_B1
+    asinh_arg_BP = term_A_BP - term_B_BP
+
+    eps = jnp.finfo(x.dtype).eps
+    clamp = clamping_factor * float(math.log(2.0 / eps))
+    asinh_arg_BP = smooth_clamp(asinh_arg_BP, -clamp, clamp, smoothing_factor)
+
+    return (z_norm_P1.T / sqrt_c) * jnp.asinh(asinh_arg_BP)
+
+
+# ---------------------------------------------------------------------------
+# Class-based manifold API
+# ---------------------------------------------------------------------------
+
+
+class ProperVelocity(ManifoldBase):
+    """Proper Velocity (PV) manifold with automatic dtype casting.
+
+    PV is an unconstrained representation of hyperbolic geometry rooted in
+    special relativity's proper velocity (Ungar 2022, Ch. 10). Points live
+    in R^n without any manifold constraint, which gives better numerical
+    stability for large radii than the bounded Poincaré ball or the
+    constrained hyperboloid (Chen et al. 2026, Tables 1-3).
+
+    Args:
+        dtype: Target JAX dtype for computations (default: ``jnp.float32``).
+
+    Examples:
+        >>> import jax.numpy as jnp
+        >>> from hyperbolix.manifolds.proper_velocity import ProperVelocity
+        >>>
+        >>> manifold = ProperVelocity(dtype=jnp.float64)
+        >>> x = jnp.array([0.1, 0.2], dtype=jnp.float32)
+        >>> y = jnp.array([0.3, 0.4], dtype=jnp.float32)
+        >>> d = manifold.dist(x, y, c=1.0)
+        >>> d.dtype  # float64
+    """
+
+    VERSION_DEFAULT = VERSION_DEFAULT
+
+    # -- Structural helpers --------------------------------------------------
+
+    def create_origin(self, c: float, dim: int) -> Float[Array, "dim"]:
+        """Create the PV origin (zero vector in R^n)."""
+        return _create_origin(c, dim, self.dtype)
+
+    def beta(self, x: Float[Array, "dim"], c: float) -> Float[Array, ""]:
+        """PV beta factor β_x = 1/√(1 + c·||x||²)."""
+        return _beta(self._cast(x), c)
+
+    # -- Gyro-operations -----------------------------------------------------
+
+    def proj(self, x: Float[Array, "dim"], c: float) -> Float[Array, "dim"]:
+        """Projection onto PV (replaces non-finite values; PV is unconstrained)."""
+        return _proj(self._cast(x), c)
+
+    def addition(self, x: Float[Array, "dim"], y: Float[Array, "dim"], c: float) -> Float[Array, "dim"]:
+        """PV gyroaddition x ⊕_U y."""
+        return _addition(self._cast(x), self._cast(y), c)
+
+    def scalar_mul(self, r: float, x: Float[Array, "dim"], c: float) -> Float[Array, "dim"]:
+        """PV scalar multiplication r ⊗_U x."""
+        x = self._cast(x)
+        r_cast = jnp.asarray(r, dtype=x.dtype)
+        return _scalar_mul(r_cast, x, c)  # type: ignore[arg-type]
+
+    # -- Distance ------------------------------------------------------------
+
+    def dist(
+        self,
+        x: Float[Array, "dim"],
+        y: Float[Array, "dim"],
+        c: float,
+        version_idx: int = VERSION_DEFAULT,
+    ) -> Float[Array, ""]:
+        """Geodesic distance between PV points."""
+        del version_idx  # only one implementation currently
+        return _dist(self._cast(x), self._cast(y), c)
+
+    def dist_0(self, x: Float[Array, "dim"], c: float, version_idx: int = VERSION_DEFAULT) -> Float[Array, ""]:
+        """Geodesic distance from the PV origin."""
+        del version_idx
+        return _dist_0(self._cast(x), c)
+
+    # -- Exp / log maps ------------------------------------------------------
+
+    def expmap(self, v: Float[Array, "dim"], x: Float[Array, "dim"], c: float) -> Float[Array, "dim"]:
+        """Exponential map at x."""
+        return _expmap(self._cast(v), self._cast(x), c)
+
+    def expmap_0(self, v: Float[Array, "dim"], c: float) -> Float[Array, "dim"]:
+        """Exponential map from the origin."""
+        return _expmap_0(self._cast(v), c)
+
+    def logmap(self, y: Float[Array, "dim"], x: Float[Array, "dim"], c: float) -> Float[Array, "dim"]:
+        """Logarithmic map at x."""
+        return _logmap(self._cast(y), self._cast(x), c)
+
+    def logmap_0(self, y: Float[Array, "dim"], c: float) -> Float[Array, "dim"]:
+        """Logarithmic map to the origin."""
+        return _logmap_0(self._cast(y), c)
+
+    def retraction(self, v: Float[Array, "dim"], x: Float[Array, "dim"], c: float) -> Float[Array, "dim"]:
+        """Euclidean retraction (exact for PV)."""
+        return _retraction(self._cast(v), self._cast(x), c)
+
+    # -- Parallel transport --------------------------------------------------
+
+    def ptransp(
+        self,
+        v: Float[Array, "dim"],
+        x: Float[Array, "dim"],
+        y: Float[Array, "dim"],
+        c: float,
+    ) -> Float[Array, "dim"]:
+        """Parallel transport v from T_x PV to T_y PV."""
+        return _ptransp(self._cast(v), self._cast(x), self._cast(y), c)
+
+    def ptransp_0(self, v: Float[Array, "dim"], y: Float[Array, "dim"], c: float) -> Float[Array, "dim"]:
+        """Parallel transport v from T_0 PV to T_y PV."""
+        return _ptransp_0(self._cast(v), self._cast(y), c)
+
+    # -- Tangent space -------------------------------------------------------
+
+    def tangent_inner(
+        self,
+        u: Float[Array, "dim"],
+        v: Float[Array, "dim"],
+        x: Float[Array, "dim"],
+        c: float,
+    ) -> Float[Array, ""]:
+        """Riemannian inner product ⟨u, v⟩_x."""
+        return _tangent_inner(self._cast(u), self._cast(v), self._cast(x), c)
+
+    def tangent_norm(self, v: Float[Array, "dim"], x: Float[Array, "dim"], c: float) -> Float[Array, ""]:
+        """Riemannian norm ||v||_x."""
+        return _tangent_norm(self._cast(v), self._cast(x), c)
+
+    def tangent_proj(self, v: Float[Array, "dim"], x: Float[Array, "dim"], c: float) -> Float[Array, "dim"]:
+        """Tangent-space projection (identity for PV)."""
+        return _tangent_proj(self._cast(v), self._cast(x), c)
+
+    def egrad2rgrad(self, grad: Float[Array, "dim"], x: Float[Array, "dim"], c: float) -> Float[Array, "dim"]:
+        """Convert Euclidean gradient to Riemannian gradient."""
+        return _egrad2rgrad(self._cast(grad), self._cast(x), c)
+
+    # -- Validation ----------------------------------------------------------
+
+    def is_in_manifold(self, x: Float[Array, "dim"], c: float, atol: float = 1e-5) -> Array:
+        """Check that all entries are finite (PV has no constraint)."""
+        return _is_in_manifold(self._cast(x), c, atol)
+
+    def is_in_tangent_space(self, v: Float[Array, "dim"], x: Float[Array, "dim"], c: float) -> Array:
+        """Check that v has finite entries (T_x PV = R^n)."""
+        return _is_in_tangent_space(self._cast(v), self._cast(x), c)
+
+    def embed_spatial_0(self, v_spatial: Float[Array, "... n"]) -> Float[Array, "... n"]:
+        """Identity embedding (no time coordinate). Kept for API parity."""
+        return _embed_spatial_0(self._cast(v_spatial))
+
+    # -- Batch helpers -------------------------------------------------------
+
+    def compute_mlr(
+        self,
+        x: Float[Array, "batch in_dim"],
+        z: Float[Array, "out_dim in_dim"],
+        r: Float[Array, "out_dim 1"],
+        c: float,
+        clamping_factor: float,
+        smoothing_factor: float,
+        min_enorm: float = 1e-15,
+    ) -> Float[Array, "batch out_dim"]:
+        """PV multinomial logistic regression (paper Thm 5.2)."""
+        return _compute_mlr(
+            self._cast(x),
+            self._cast(z),
+            self._cast(r),
+            c,
+            clamping_factor,
+            smoothing_factor,
+            min_enorm,
+        )

--- a/hyperbolix/nn_layers/__init__.py
+++ b/hyperbolix/nn_layers/__init__.py
@@ -44,6 +44,7 @@ from .poincare_batchnorm import PoincareBatchNorm2D, frechet_variance, poincare_
 from .poincare_conv import HypConv2DPoincare
 from .poincare_linear import HypLinearPoincare, HypLinearPoincarePP
 from .poincare_regression import HypRegressionPoincare, HypRegressionPoincarePP
+from .pv_conv import HypConv2DPV
 from .pv_linear import HypLinearPV
 from .pv_regression import HypRegressionPV
 
@@ -60,6 +61,7 @@ __all__ = [
     "HypConv2DHyperboloid",
     "HypConv2DHyperboloidFHNN",
     "HypConv2DHyperboloidPP",
+    "HypConv2DPV",
     "HypConv2DPoincare",
     "HypLinearHyperboloidFHCNN",
     "HypLinearHyperboloidFHNN",

--- a/hyperbolix/nn_layers/__init__.py
+++ b/hyperbolix/nn_layers/__init__.py
@@ -44,6 +44,8 @@ from .poincare_batchnorm import PoincareBatchNorm2D, frechet_variance, poincare_
 from .poincare_conv import HypConv2DPoincare
 from .poincare_linear import HypLinearPoincare, HypLinearPoincarePP
 from .poincare_regression import HypRegressionPoincare, HypRegressionPoincarePP
+from .pv_linear import HypLinearPV
+from .pv_regression import HypRegressionPV
 
 __all__ = [
     "FGGConv2D",
@@ -62,9 +64,11 @@ __all__ = [
     "HypLinearHyperboloidFHCNN",
     "HypLinearHyperboloidFHNN",
     "HypLinearHyperboloidPP",
+    "HypLinearPV",
     "HypLinearPoincare",
     "HypLinearPoincarePP",
     "HypRegressionHyperboloid",
+    "HypRegressionPV",
     "HypRegressionPoincare",
     "HypRegressionPoincarePP",
     "HyperPPFeatureScaling",

--- a/hyperbolix/nn_layers/_helpers.py
+++ b/hyperbolix/nn_layers/_helpers.py
@@ -30,3 +30,12 @@ def validate_poincare_manifold(manifold_module: Manifold, required_methods: tupl
         manifold_name="Poincare",
         example_instance="hyperbolix.manifolds.Poincare()",
     )
+
+
+def validate_pv_manifold(manifold_module: Manifold, required_methods: tuple[str, ...]) -> None:
+    _validate_manifold_methods(
+        manifold_module,
+        required_methods,
+        manifold_name="ProperVelocity",
+        example_instance="hyperbolix.manifolds.ProperVelocity()",
+    )

--- a/hyperbolix/nn_layers/pv_conv.py
+++ b/hyperbolix/nn_layers/pv_conv.py
@@ -1,0 +1,210 @@
+"""Proper Velocity convolutional layers for JAX/Flax NNX.
+
+Implements the PV convolution from Chen et al. 2026, Sec 5.3. PV's unconstrained
+``ℝⁿ`` nature makes this simpler than the Poincaré analogue: patch concatenation
+coincides with Euclidean concatenation, so no beta-scaling step is required, and
+outputs can stay on the PV manifold without a tangent-space round-trip.
+
+Computation flow:
+
+    pv_input (optional expmap_0) → conv_general_dilated_patches (zero-padded)
+                                 → raw concat → HypLinearPV FC → pv_output
+
+Dimension key:
+  B: batch size
+  H: output height        W: output width
+  C: channels (in/out)    K: kernel elements (kh*kw)
+  N: flattened batch+spatial (B*H*W)
+"""
+
+from collections.abc import Callable
+
+import jax
+from flax import nnx
+from jaxtyping import Array, Float
+
+from hyperbolix.manifolds.proper_velocity import ProperVelocity
+
+from ._helpers import validate_pv_manifold
+from .pv_linear import _pv_fc_forward
+
+
+class HypConv2DPV(nnx.Module):
+    """
+    Hyperbolic 2D Convolutional Layer for the Proper Velocity model.
+
+    Implements Chen et al. 2026, Sec 5.3. Because PV's geometry is unconstrained
+    (``ℝⁿ``), patch concatenation coincides with Euclidean concatenation — no
+    beta-scaling step is required (unlike ``HypConv2DPoincare``). The layer
+    returns points on the PV manifold; between conv layers, activations can be
+    applied directly in PV space (paper Sec 5.3 "Activation").
+
+    Computation steps:
+        1) Optionally lift tangent-space input to the PV manifold via ``expmap_0``.
+        2) Extract patches with zero-padding via ``jax.lax.conv_general_dilated_patches``.
+        3) Flatten batch x spatial dimensions.
+        4) Apply the PV FC forward (``_pv_fc_forward``, shared with ``HypLinearPV``).
+        5) Reshape back to spatial output.
+
+    Parameters
+    ----------
+    manifold_module : ProperVelocity
+        Class-based Proper Velocity manifold instance.
+    in_channels : int
+        Number of input channels (PV dimension per pixel).
+    out_channels : int
+        Number of output channels (PV dimension per pixel).
+    kernel_size : int or tuple[int, int]
+        Size of the convolutional kernel.
+    rngs : nnx.Rngs
+        Random number generators for parameter initialization.
+    stride : int or tuple[int, int]
+        Stride of the convolution (default: 1).
+    padding : str
+        Padding mode, either 'SAME' or 'VALID' (default: 'SAME').
+    input_space : str
+        Type of the input tensor, either 'tangent' or 'manifold' (default: 'manifold').
+        Note: This is a static configuration — changing it after initialization
+        requires recompilation.
+    inner_activation : Callable[[Array], Array] | None
+        Optional activation applied inside the outer sinh (paper Eq. 23). Default None.
+    clamping_factor : float
+        Clamping factor for the PV MLR output (default: 1.0).
+    smoothing_factor : float
+        Smoothing factor for the PV MLR output (default: 50.0).
+    kernel_init_std : float | None
+        Standard deviation for the Gaussian kernel init. If ``None`` (default),
+        uses He scaling ``sqrt(2 / (kernel_h * kernel_w * in_channels))`` so
+        stacked conv blocks preserve variance under ReLU (for small MLR
+        arguments the PV output reduces to an Euclidean linear map per patch,
+        so standard He analysis applies).
+
+    Notes
+    -----
+    Output Space:
+        Unlike ``HypConv2DPoincare`` (which returns tangent space), this layer
+        returns points on the PV manifold. Between conv layers, apply activations
+        directly on the PV features — no expmap_0/logmap_0 round-trips needed.
+
+    JIT Compatibility:
+        Configuration parameters (padding, input_space, inner_activation,
+        clamping_factor, smoothing_factor) are treated as static and are baked
+        into the compiled function.
+
+    Dimension math:
+        - patch extraction: (H, W, C_in) → (oh, ow, K²·C_in)
+        - PV FC: in_dim = K²·C_in, out_dim = C_out
+
+    References
+    ----------
+    Chen et al. "Proper Velocity Neural Networks." ICLR 2026.
+    """
+
+    def __init__(
+        self,
+        manifold_module: ProperVelocity,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int | tuple[int, int],
+        *,
+        rngs: nnx.Rngs,
+        stride: int | tuple[int, int] = 1,
+        padding: str = "SAME",
+        input_space: str = "manifold",
+        inner_activation: Callable[[Array], Array] | None = None,
+        clamping_factor: float = 1.0,
+        smoothing_factor: float = 50.0,
+        kernel_init_std: float | None = None,
+    ):
+        if padding not in ["SAME", "VALID"]:
+            raise ValueError(f"padding must be either 'SAME' or 'VALID', got '{padding}'")
+        if input_space not in ["tangent", "manifold"]:
+            raise ValueError(f"input_space must be either 'tangent' or 'manifold', got '{input_space}'")
+
+        validate_pv_manifold(
+            manifold_module,
+            required_methods=("expmap_0", "compute_mlr"),
+        )
+        self.manifold = manifold_module
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.input_space = input_space
+        self.padding = padding
+        self.inner_activation = inner_activation
+        self.clamping_factor = clamping_factor
+        self.smoothing_factor = smoothing_factor
+
+        # Handle kernel_size / stride as int or tuple.
+        self.kernel_size = (kernel_size, kernel_size) if isinstance(kernel_size, int) else kernel_size
+        self.stride = (stride, stride) if isinstance(stride, int) else stride
+
+        kernel_h, kernel_w = self.kernel_size
+        concat_dim = kernel_h * kernel_w * in_channels
+
+        # Kernel init: He(fan_in) by default so deep conv stacks preserve
+        # variance under ReLU. Bias init is uniform U(-1e-3, 1e-3), matching
+        # the paper reference.
+        std = (2.0 / concat_dim) ** 0.5 if kernel_init_std is None else kernel_init_std
+        self.kernel = nnx.Param(jax.random.normal(rngs.params(), (out_channels, concat_dim)) * std)
+        self.bias = nnx.Param(jax.random.uniform(rngs.params(), (out_channels, 1), minval=-1e-3, maxval=1e-3))
+
+    def __call__(
+        self,
+        x: Float[Array, "batch height width in_channels"],
+        c: float = 1.0,
+    ) -> Float[Array, "batch out_height out_width out_channels"]:
+        """
+        Forward pass through the PV convolutional layer.
+
+        Parameters
+        ----------
+        x : Array of shape (batch, height, width, in_channels)
+            Input feature map. PV manifold points or tangent-space vectors at the
+            origin, depending on ``input_space``.
+        c : float
+            Manifold curvature (default: 1.0).
+
+        Returns
+        -------
+        out : Array of shape (batch, out_height, out_width, out_channels)
+            Output feature map on the PV manifold.
+        """
+        # Step 1: Optionally lift tangent-space input to the PV manifold.
+        if self.input_space == "tangent":
+            orig_shape = x.shape
+            x_flat_NC = x.reshape(-1, x.shape[-1])  # (B*H*W, C_in)
+            x_flat_NC = jax.vmap(self.manifold.expmap_0, in_axes=(0, None))(x_flat_NC, c)
+            x = x_flat_NC.reshape(orig_shape)
+
+        # Step 2: Extract patches with zero-padding (raw concat — no beta scaling).
+        kernel_h, kernel_w = self.kernel_size
+        stride_h, stride_w = self.stride
+
+        patches_BHWKC = jax.lax.conv_general_dilated_patches(
+            lhs=x,
+            filter_shape=(kernel_h, kernel_w),
+            window_strides=(stride_h, stride_w),
+            padding=self.padding,
+            dimension_numbers=("NHWC", "OIHW", "NHWC"),
+        )  # (B, H, W, K²·C_in)
+
+        batch, out_h, out_w, concat_dim = patches_BHWKC.shape
+
+        # Step 3: Flatten batch x spatial dims for the FC.
+        patches_flat_NKC = patches_BHWKC.reshape(-1, concat_dim)  # (N, K²·C_in)
+
+        # Step 4: PV FC — input is already on the PV manifold (no extra lift).
+        fc_out_NC = _pv_fc_forward(
+            patches_flat_NKC,
+            self.kernel[...],
+            self.bias[...],
+            self.manifold,
+            c,
+            "manifold",
+            self.clamping_factor,
+            self.smoothing_factor,
+            self.inner_activation,
+        )  # (N, C_out) on PV manifold
+
+        # Step 5: Reshape to spatial output.
+        return fc_out_NC.reshape(batch, out_h, out_w, self.out_channels)

--- a/hyperbolix/nn_layers/pv_linear.py
+++ b/hyperbolix/nn_layers/pv_linear.py
@@ -93,6 +93,15 @@ class HypLinearPV(nnx.Module):
         Clamping factor for the MLR output (default: 1.0).
     smoothing_factor : float
         Smoothing factor for the MLR output (default: 50.0).
+    kernel_init_std : float | None
+        Standard deviation for the Gaussian kernel init. If ``None`` (default),
+        uses He scaling ``sqrt(2 / in_dim)`` so stacked layers preserve variance
+        under ReLU activations (for small MLR arguments the PV output reduces to
+        an Euclidean linear map, so standard He analysis applies). Pass a
+        specific value (e.g. ``1e-2``) when using this layer as the final
+        classification/regression layer directly before a softmax/MSE loss —
+        that matches the paper's ``PVManifoldMLR.reset_parameters`` recipe,
+        which is tuned for receiving ``O(1)``-variance features.
 
     Notes
     -----
@@ -116,6 +125,7 @@ class HypLinearPV(nnx.Module):
         inner_activation: Callable[[Array], Array] | None = None,
         clamping_factor: float = 1.0,
         smoothing_factor: float = 50.0,
+        kernel_init_std: float | None = None,
     ):
         if input_space not in ["tangent", "manifold"]:
             raise ValueError(f"input_space must be either 'tangent' or 'manifold', got '{input_space}'")
@@ -132,11 +142,12 @@ class HypLinearPV(nnx.Module):
         self.clamping_factor = clamping_factor
         self.smoothing_factor = smoothing_factor
 
-        # Kernel init: std = (2 · in_dim · out_dim)^{-0.5} (matches hyperbolix convention
-        # for Poincaré layers; small-norm kernels keep the asinh argument near zero at init).
-        std = 1.0 / jnp.sqrt(2.0 * in_dim * out_dim)
+        # Kernel init: He(in_dim) by default so deep stacks preserve variance
+        # under ReLU. Override via ``kernel_init_std`` when using as a final
+        # classification layer — see the ``kernel_init_std`` docstring above.
+        # Bias init is uniform U(-1e-3, 1e-3), matching the paper reference.
+        std = (2.0 / in_dim) ** 0.5 if kernel_init_std is None else kernel_init_std
         self.kernel = nnx.Param(jax.random.normal(rngs.params(), (out_dim, in_dim)) * std)
-        # Bias: small uniform U(-1e-3, 1e-3) (matches paper reference PVManifoldMLR init).
         self.bias = nnx.Param(jax.random.uniform(rngs.params(), (out_dim, 1), minval=-1e-3, maxval=1e-3))
 
     def __call__(

--- a/hyperbolix/nn_layers/pv_linear.py
+++ b/hyperbolix/nn_layers/pv_linear.py
@@ -1,0 +1,173 @@
+"""Proper Velocity linear layers for JAX/Flax NNX.
+
+Implements the PV fully-connected layer from Chen et al. 2026
+(Thm 5.3 / Eq. 22):
+
+    y_k = (1/√c) · sinh(√c · v_k(x))
+
+where ``v_k(x)`` is the PV multinomial-logistic-regression score from Eq. 19
+(implemented as ``ProperVelocity.compute_mlr``). An optional inner activation
+``sigma`` inside the sinh mirrors the paper's Eq. 23 ablation.
+
+Dimension key:
+  B: batch size       I: input dimension       O: output dimension
+"""
+
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jaxtyping import Array, Float
+
+from hyperbolix.manifolds.proper_velocity import ProperVelocity
+
+from ..utils.math_utils import sinh
+from ._helpers import validate_pv_manifold
+
+
+def _pv_fc_forward(
+    x_BI: Float[Array, "batch in_dim"],
+    kernel_OI: Array,
+    bias_O1: Array,
+    manifold: ProperVelocity,
+    c: float,
+    input_space: str,
+    clamping_factor: float,
+    smoothing_factor: float,
+    inner_activation: Callable[[Array], Array] | None = None,
+) -> Float[Array, "batch out_dim"]:
+    """Pure-function PV FC forward pass (paper Thm 5.3 / Eq. 22).
+
+    Used by both ``HypLinearPV`` and ``HypConv2DPV``.
+
+    Steps:
+      1) Optional lift Euclidean input via ``expmap_0`` if ``input_space == "tangent"``.
+      2) Compute PV MLR scores ``v`` via ``manifold.compute_mlr``.
+      3) Optionally apply ``inner_activation`` to ``v`` (paper Eq. 23).
+      4) Return ``(1/√c) · sinh(√c · v)`` — a PV-manifold point.
+    """
+    # Map to manifold if needed (static branch — JIT friendly).
+    if input_space == "tangent":
+        x_BI = jax.vmap(manifold.expmap_0, in_axes=(0, None), out_axes=0)(x_BI, c)
+
+    v_BO = manifold.compute_mlr(x_BI, kernel_OI, bias_O1, c, clamping_factor, smoothing_factor)
+
+    if inner_activation is not None:
+        v_BO = inner_activation(v_BO)
+
+    sqrt_c = jnp.sqrt(jnp.asarray(c, dtype=v_BO.dtype))
+    return sinh(sqrt_c * v_BO) / sqrt_c
+
+
+class HypLinearPV(nnx.Module):
+    """
+    Hyperbolic Neural Networks fully connected layer (Proper Velocity model).
+
+    Implements Chen et al. 2026, Thm 5.3 / Eq. 22:
+
+        y_k = (1/√c) · sinh(√c · v_k(x))
+
+    where ``v_k(x)`` is the PV multinomial-logistic-regression signed margin
+    from Eq. 19 (implemented as ``ProperVelocity.compute_mlr``). The optional
+    ``inner_activation`` realizes the Eq. 23 ablation from the paper.
+
+    Parameters
+    ----------
+    manifold_module : ProperVelocity
+        Class-based Proper Velocity manifold instance.
+    in_dim : int
+        Dimension of the input space.
+    out_dim : int
+        Dimension of the output space.
+    rngs : nnx.Rngs
+        Random number generators for parameter initialization.
+    input_space : str
+        Type of the input tensor, either 'tangent' or 'manifold' (default: 'manifold').
+        Note: This is a static configuration — changing it after initialization
+        requires recompilation.
+    inner_activation : Callable[[Array], Array] | None
+        Optional activation applied to ``v`` before the outer sinh
+        (paper Eq. 23 ablation). Default None.
+    clamping_factor : float
+        Clamping factor for the MLR output (default: 1.0).
+    smoothing_factor : float
+        Smoothing factor for the MLR output (default: 50.0).
+
+    Notes
+    -----
+    JIT Compatibility:
+        Configuration parameters (input_space, clamping_factor, smoothing_factor,
+        inner_activation) are treated as static and are baked into the compiled function.
+
+    References
+    ----------
+    Chen et al. "Proper Velocity Neural Networks." ICLR 2026.
+    """
+
+    def __init__(
+        self,
+        manifold_module: ProperVelocity,
+        in_dim: int,
+        out_dim: int,
+        *,
+        rngs: nnx.Rngs,
+        input_space: str = "manifold",
+        inner_activation: Callable[[Array], Array] | None = None,
+        clamping_factor: float = 1.0,
+        smoothing_factor: float = 50.0,
+    ):
+        if input_space not in ["tangent", "manifold"]:
+            raise ValueError(f"input_space must be either 'tangent' or 'manifold', got '{input_space}'")
+
+        validate_pv_manifold(
+            manifold_module,
+            required_methods=("expmap_0", "compute_mlr"),
+        )
+        self.manifold = manifold_module
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+        self.input_space = input_space
+        self.inner_activation = inner_activation
+        self.clamping_factor = clamping_factor
+        self.smoothing_factor = smoothing_factor
+
+        # Kernel init: std = (2 · in_dim · out_dim)^{-0.5} (matches hyperbolix convention
+        # for Poincaré layers; small-norm kernels keep the asinh argument near zero at init).
+        std = 1.0 / jnp.sqrt(2.0 * in_dim * out_dim)
+        self.kernel = nnx.Param(jax.random.normal(rngs.params(), (out_dim, in_dim)) * std)
+        # Bias: small uniform U(-1e-3, 1e-3) (matches paper reference PVManifoldMLR init).
+        self.bias = nnx.Param(jax.random.uniform(rngs.params(), (out_dim, 1), minval=-1e-3, maxval=1e-3))
+
+    def __call__(
+        self,
+        x: Float[Array, "batch in_dim"],
+        c: float = 1.0,
+    ) -> Float[Array, "batch out_dim"]:
+        """
+        Forward pass through the PV linear layer.
+
+        Parameters
+        ----------
+        x : Array of shape (batch, in_dim)
+            Input — PV manifold points or tangent vectors at origin, depending on
+            ``input_space``.
+        c : float
+            Manifold curvature (default: 1.0).
+
+        Returns
+        -------
+        res : Array of shape (batch, out_dim)
+            Output points on the PV manifold.
+        """
+        return _pv_fc_forward(
+            x,
+            self.kernel[...],
+            self.bias[...],
+            self.manifold,
+            c,
+            self.input_space,
+            self.clamping_factor,
+            self.smoothing_factor,
+            self.inner_activation,
+        )

--- a/hyperbolix/nn_layers/pv_regression.py
+++ b/hyperbolix/nn_layers/pv_regression.py
@@ -1,0 +1,124 @@
+"""Proper Velocity regression layers for JAX/Flax NNX.
+
+Implements the PV multinomial-logistic-regression layer from Chen et al. 2026
+(Thm 5.2 / Eq. 19). Delegates to ``ProperVelocity.compute_mlr`` which returns
+Euclidean logits suitable as input to a softmax-cross-entropy loss.
+
+Dimension key:
+  B: batch size       I: input dimension       P: number of classes (out_dim)
+"""
+
+import jax
+from flax import nnx
+from jaxtyping import Array, Float
+
+from hyperbolix.manifolds.proper_velocity import ProperVelocity
+
+from ._helpers import validate_pv_manifold
+
+
+class HypRegressionPV(nnx.Module):
+    """
+    Hyperbolic multinomial logistic regression layer (Proper Velocity model).
+
+    Implements Chen et al. 2026, Thm 5.2 / Eq. 19, delegating to
+    ``ProperVelocity.compute_mlr``. The output is the Euclidean signed margin
+    to each PV hyperplane and is intended to be consumed by a standard
+    softmax-cross-entropy classification loss.
+
+    Computation steps:
+        0) Optionally lift tangent-space input via ``expmap_0``.
+        1) Compute the PV MLR scores via ``manifold.compute_mlr``.
+
+    Parameters
+    ----------
+    manifold_module : ProperVelocity
+        Class-based Proper Velocity manifold instance.
+    in_dim : int
+        Dimension of the input space.
+    out_dim : int
+        Dimension of the output space (number of classes).
+    rngs : nnx.Rngs
+        Random number generators for parameter initialization.
+    input_space : str
+        Type of the input tensor, either 'tangent' or 'manifold' (default: 'manifold').
+        Note: This is a static configuration — changing it after initialization
+        requires recompilation.
+    clamping_factor : float
+        Clamping factor for the MLR output (default: 1.0).
+    smoothing_factor : float
+        Smoothing factor for the MLR output (default: 50.0).
+
+    Notes
+    -----
+    JIT Compatibility:
+        Configuration parameters (input_space, clamping_factor, smoothing_factor)
+        are treated as static and are baked into the compiled function.
+
+    References
+    ----------
+    Chen et al. "Proper Velocity Neural Networks." ICLR 2026.
+    """
+
+    def __init__(
+        self,
+        manifold_module: ProperVelocity,
+        in_dim: int,
+        out_dim: int,
+        *,
+        rngs: nnx.Rngs,
+        input_space: str = "manifold",
+        clamping_factor: float = 1.0,
+        smoothing_factor: float = 50.0,
+    ):
+        if input_space not in ["tangent", "manifold"]:
+            raise ValueError(f"input_space must be either 'tangent' or 'manifold', got '{input_space}'")
+
+        validate_pv_manifold(
+            manifold_module,
+            required_methods=("expmap_0", "compute_mlr"),
+        )
+        self.manifold = manifold_module
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+        self.input_space = input_space
+        self.clamping_factor = clamping_factor
+        self.smoothing_factor = smoothing_factor
+
+        # Kernel init: small normal with std = 1e-2 (matches paper reference
+        # PVManifoldMLR.reset_parameters in the Chen et al. repo).
+        self.kernel = nnx.Param(jax.random.normal(rngs.params(), (out_dim, in_dim)) * 1e-2)
+        # Bias init: uniform U(-1e-3, 1e-3) (matches paper reference).
+        self.bias = nnx.Param(jax.random.uniform(rngs.params(), (out_dim, 1), minval=-1e-3, maxval=1e-3))
+
+    def __call__(
+        self,
+        x: Float[Array, "batch in_dim"],
+        c: float = 1.0,
+    ) -> Float[Array, "batch out_dim"]:
+        """
+        Forward pass through the PV regression layer.
+
+        Parameters
+        ----------
+        x : Array of shape (batch, in_dim)
+            Input tensor — PV manifold points or tangent-space vectors.
+        c : float
+            Manifold curvature (default: 1.0).
+
+        Returns
+        -------
+        res : Array of shape (batch, out_dim)
+            MLR logits (Euclidean, suitable for cross-entropy).
+        """
+        if self.input_space == "tangent":
+            x = jax.vmap(self.manifold.expmap_0, in_axes=(0, None), out_axes=0)(x, c)
+
+        return self.manifold.compute_mlr(
+            x,
+            self.kernel[...],
+            self.bias[...],
+            c,
+            self.clamping_factor,
+            self.smoothing_factor,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,8 +49,9 @@ def tolerance(dtype: jnp.dtype) -> tuple[float, float]:
         ("euclidean", 0.0),
         ("poincare", 1.0),
         ("hyperboloid", 1.0),
+        ("pv", 1.0),
     ],
-    ids=["Euclidean", "PoincareBall", "Hyperboloid"],
+    ids=["Euclidean", "PoincareBall", "Hyperboloid", "ProperVelocity"],
 )
 def manifold_and_c(request: pytest.FixtureRequest, dtype: jnp.dtype, rng: np.random.Generator):
     """Fixture providing (manifold_instance, curvature) tuples.
@@ -72,6 +73,10 @@ def manifold_and_c(request: pytest.FixtureRequest, dtype: jnp.dtype, rng: np.ran
         # Hyperboloid with random positive curvature
         c = float(rng.exponential(scale=2.0))
         return hj.manifolds.Hyperboloid(dtype=dtype), c
+    elif manifold_name == "pv":
+        # Proper Velocity with random positive curvature (same distribution as Poincaré)
+        c = float(rng.exponential(scale=2.0))
+        return hj.manifolds.ProperVelocity(dtype=dtype), c
     else:
         raise ValueError(f"Unknown manifold: {manifold_name}")
 
@@ -137,6 +142,14 @@ def uniform_points(manifold_and_c, dtype: jnp.dtype, request: pytest.FixtureRequ
         # Project to ensure they're on the manifold
         proj_batch = jax.vmap(manifold.proj, in_axes=(0, None))
         return proj_batch(points, c)
+
+    elif isinstance(manifold, hj.manifolds.ProperVelocity):
+        # Proper Velocity: unconstrained ℝⁿ. Gaussian samples scaled to 1/√c keep
+        # typical geodesic distance to origin of order asinh(1) ~ 0.88, mirroring
+        # the hyperbolic manifolds' "moderate distance" regime.
+        data = rng.normal(0.0, 1.0, size=(num_pts, dim)).astype(np_dtype)
+        data = data / np.sqrt(c)
+        return jnp.asarray(data, dtype=dtype)
 
     else:
         raise ValueError("Unknown manifold module")

--- a/tests/nn_layers/test_pv_conv.py
+++ b/tests/nn_layers/test_pv_conv.py
@@ -1,0 +1,336 @@
+"""Tests for HypConv2DPV (Proper Velocity conv, Chen et al. 2026, Sec 5.3)."""
+
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from hyperbolix.manifolds import ProperVelocity
+from hyperbolix.nn_layers import HypConv2DPV
+
+
+def _manifold(dtype: jnp.dtype) -> ProperVelocity:
+    return ProperVelocity(dtype=dtype)
+
+
+def _manifold_input(dtype: jnp.dtype, shape: tuple[int, ...], seed: int = 0) -> jnp.ndarray:
+    """Gaussian samples: valid PV points (PV is unconstrained)."""
+    return jax.random.normal(jax.random.PRNGKey(seed), shape, dtype=dtype) * 0.3
+
+
+@pytest.mark.parametrize("kernel_size", [1, 3, 5])
+@pytest.mark.parametrize("padding", ["SAME", "VALID"])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_output_shape(kernel_size, padding, dtype):
+    batch_size, height, width, in_channels, out_channels = 2, 8, 8, 3, 4
+    x = _manifold_input(dtype, (batch_size, height, width, in_channels))
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DPV(
+        manifold_module=_manifold(dtype),
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        rngs=rngs,
+        padding=padding,
+    )
+
+    y = layer(x, c=1.0)
+
+    if padding == "SAME":
+        expected_h, expected_w = height, width
+    else:
+        expected_h = height - kernel_size + 1
+        expected_w = width - kernel_size + 1
+
+    assert y.shape == (batch_size, expected_h, expected_w, out_channels)
+    assert jnp.isfinite(y).all()
+    assert y.dtype == dtype
+
+
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_stride(stride, dtype):
+    batch_size, height, width, in_channels, out_channels = 2, 8, 8, 3, 4
+    kernel_size = 3
+    x = _manifold_input(dtype, (batch_size, height, width, in_channels))
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DPV(
+        manifold_module=_manifold(dtype),
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        rngs=rngs,
+        padding="SAME",
+    )
+
+    y = layer(x, c=1.0)
+
+    expected_h = (height + stride - 1) // stride
+    expected_w = (width + stride - 1) // stride
+    assert y.shape == (batch_size, expected_h, expected_w, out_channels)
+    assert jnp.isfinite(y).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_output_on_manifold(dtype):
+    """HypConv2DPV returns PV manifold points — verify all are valid."""
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
+    manifold = _manifold(dtype)
+    x = _manifold_input(dtype, (batch_size, height, width, in_channels))
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DPV(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=rngs,
+    )
+
+    y = layer(x, c=1.0)
+    y_flat = y.reshape(-1, out_channels)
+    is_on = jax.vmap(manifold.is_in_manifold, in_axes=(0, None))(y_flat, 1.0)
+    assert bool(is_on.all())
+
+
+@pytest.mark.parametrize("input_space", ["manifold", "tangent"])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_input_space_modes(input_space, dtype):
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
+    x = _manifold_input(dtype, (batch_size, height, width, in_channels))
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DPV(
+        manifold_module=_manifold(dtype),
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=rngs,
+        input_space=input_space,
+    )
+
+    y = layer(x, c=1.0)
+    assert jnp.isfinite(y).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_tangent_matches_manual_lift(dtype):
+    """input_space='tangent' must equal manual expmap_0 + input_space='manifold'."""
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 4
+    manifold = _manifold(dtype)
+    v = _manifold_input(dtype, (batch_size, height, width, in_channels))
+
+    # Manually lift per-pixel.
+    v_flat = v.reshape(-1, in_channels)
+    x_flat = jax.vmap(manifold.expmap_0, in_axes=(0, None))(v_flat, 1.0)
+    x = x_flat.reshape(v.shape)
+
+    manifold_layer = HypConv2DPV(manifold, in_channels, out_channels, 3, rngs=nnx.Rngs(7), input_space="manifold")
+    tangent_layer = HypConv2DPV(manifold, in_channels, out_channels, 3, rngs=nnx.Rngs(7), input_space="tangent")
+
+    y_manual = manifold_layer(x, c=1.0)
+    y_tangent = tangent_layer(v, c=1.0)
+
+    atol = 1e-5 if dtype == jnp.float32 else 1e-10
+    assert jnp.allclose(y_manual, y_tangent, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_gradient(dtype):
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
+    x = _manifold_input(dtype, (batch_size, height, width, in_channels))
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DPV(
+        manifold_module=_manifold(dtype),
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=rngs,
+    )
+
+    def loss_fn(model):
+        y = model(x, c=1.0)
+        return jnp.sum(y**2)
+
+    loss, grads = nnx.value_and_grad(loss_fn)(layer)
+
+    assert jnp.isfinite(loss)
+    assert jnp.isfinite(grads.kernel[...]).all()
+    assert jnp.isfinite(grads.bias[...]).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_jitted(dtype):
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
+    x = _manifold_input(dtype, (batch_size, height, width, in_channels))
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DPV(
+        manifold_module=_manifold(dtype),
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=rngs,
+    )
+
+    @nnx.jit
+    def forward(module, inputs, curvature):
+        return module(inputs, c=curvature)
+
+    y = forward(layer, x, 1.0)
+    assert jnp.isfinite(y).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_init_default_he(dtype):
+    """Default kernel init is He(fan_in); bias is uniform U(-1e-3, 1e-3).
+
+    Default changed from the paper's z ~ N(0, 1e-2) to He scaling so deep
+    fully-hyperbolic PV conv stacks preserve variance under ReLU. Use the
+    ``kernel_init_std`` override to restore the paper recipe.
+    """
+    in_channels, out_channels, kernel_size = 3, 4, 3
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DPV(
+        manifold_module=_manifold(dtype),
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        rngs=rngs,
+    )
+
+    kernel = layer.kernel[...]
+    bias = layer.bias[...]
+
+    concat_dim = kernel_size * kernel_size * in_channels
+    assert kernel.shape == (out_channels, concat_dim)
+    assert bias.shape == (out_channels, 1)
+    # He default: std ≈ sqrt(2/concat_dim). For fan_in=27, target std ≈ 0.272.
+    expected_std = (2.0 / concat_dim) ** 0.5
+    empirical_std = float(jnp.std(kernel))
+    assert 0.5 * expected_std < empirical_std < 1.5 * expected_std, (
+        f"kernel std {empirical_std:.3e} not within 0.5x..1.5x He target {expected_std:.3e}"
+    )
+    # Uniform |bias| <= 1e-3.
+    assert jnp.max(jnp.abs(bias)) <= 1e-3
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_init_paper_override(dtype):
+    """``kernel_init_std=1e-2`` reproduces the paper's PVManifoldMLR recipe."""
+    in_channels, out_channels, kernel_size = 3, 4, 3
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DPV(
+        manifold_module=_manifold(dtype),
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        rngs=rngs,
+        kernel_init_std=1e-2,
+    )
+
+    kernel = layer.kernel[...]
+    # std ~ 1e-2 → each entry well within |0.1| for 42-seeded RNG.
+    assert jnp.max(jnp.abs(kernel)) < 0.1, f"kernel too large for std=1e-2 override: max={jnp.max(jnp.abs(kernel))}"
+
+
+@pytest.mark.parametrize("c", [0.1, 1.0, 2.0])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_different_curvatures(dtype, c):
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
+    manifold = _manifold(dtype)
+    x = _manifold_input(dtype, (batch_size, height, width, in_channels))
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DPV(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=rngs,
+    )
+
+    y = layer(x, c=c)
+    assert jnp.isfinite(y).all()
+    y_flat = y.reshape(-1, out_channels)
+    is_on = jax.vmap(partial(manifold.is_in_manifold, c=c))(y_flat)
+    assert bool(is_on.all())
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_chained_with_activation(dtype):
+    """Chain two PV convs with relu applied directly on PV points (Sec 5.3)."""
+    manifold = _manifold(dtype)
+    batch_size, height, width = 2, 8, 8
+    c = 1.0
+
+    x = _manifold_input(dtype, (batch_size, height, width, 3))
+
+    conv1 = HypConv2DPV(manifold, 3, 8, kernel_size=3, stride=2, rngs=nnx.Rngs(42))
+    conv2 = HypConv2DPV(manifold, 8, 16, kernel_size=3, stride=2, rngs=nnx.Rngs(43))
+
+    y = conv1(x, c)
+    y = jax.nn.relu(y)
+    y = conv2(y, c)
+    y = jax.nn.relu(y)
+
+    expected_h = (height + 1) // 2
+    expected_h2 = (expected_h + 1) // 2
+    assert y.shape == (batch_size, expected_h2, expected_h2, 16)
+    assert jnp.isfinite(y).all()
+
+    def loss_fn(m1, m2):
+        h = m1(x, c)
+        h = jax.nn.relu(h)
+        h = m2(h, c)
+        return jnp.sum(h**2)
+
+    loss, (grads1, grads2) = nnx.value_and_grad(loss_fn, argnums=(0, 1))(conv1, conv2)
+    assert jnp.isfinite(loss)
+    assert jnp.isfinite(grads1.kernel[...]).all()
+    assert jnp.isfinite(grads2.kernel[...]).all()
+
+
+@pytest.mark.parametrize("activation", [jax.nn.relu, jnp.tanh])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_conv_inner_activation(dtype, activation):
+    """inner_activation applies inside the outer sinh (paper Eq. 23)."""
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 4
+    x = _manifold_input(dtype, (batch_size, height, width, in_channels))
+
+    rngs = nnx.Rngs(42)
+    layer = HypConv2DPV(
+        manifold_module=_manifold(dtype),
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=rngs,
+        inner_activation=activation,
+    )
+
+    y = layer(x, c=1.0)
+    assert jnp.isfinite(y).all()
+
+
+def test_pv_conv_rejects_bad_padding():
+    with pytest.raises(ValueError, match="padding"):
+        HypConv2DPV(_manifold(jnp.float32), 3, 4, 3, rngs=nnx.Rngs(0), padding="REFLECT")
+
+
+def test_pv_conv_rejects_bad_input_space():
+    with pytest.raises(ValueError, match="input_space"):
+        HypConv2DPV(_manifold(jnp.float32), 3, 4, 3, rngs=nnx.Rngs(0), input_space="nope")
+
+
+def test_pv_conv_rejects_non_pv_manifold():
+    class Fake:
+        pass
+
+    with pytest.raises(TypeError, match="ProperVelocity"):
+        HypConv2DPV(Fake(), 3, 4, 3, rngs=nnx.Rngs(0))  # type: ignore[arg-type]

--- a/tests/nn_layers/test_pv_linear.py
+++ b/tests/nn_layers/test_pv_linear.py
@@ -217,6 +217,42 @@ def test_pv_linear_rejects_bad_input_space():
         HypLinearPV(_manifold(jnp.float32), 3, 2, rngs=nnx.Rngs(0), input_space="nope")
 
 
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_init_default_he(dtype):
+    """Default kernel init is He(in_dim); bias is uniform U(-1e-3, 1e-3).
+
+    Default changed from the paper's z ~ N(0, 1e-2) to He scaling so deep
+    fully-hyperbolic PV stacks preserve variance under ReLU. Use the
+    ``kernel_init_std`` override to restore the paper recipe (appropriate
+    when this layer is the final classification layer before a softmax
+    cross-entropy loss).
+    """
+    in_dim, out_dim = 64, 32
+    layer = HypLinearPV(_manifold(dtype), in_dim, out_dim, rngs=nnx.Rngs(42))
+
+    kernel = layer.kernel[...]
+    bias = layer.bias[...]
+
+    assert kernel.shape == (out_dim, in_dim)
+    assert bias.shape == (out_dim, 1)
+    expected_std = (2.0 / in_dim) ** 0.5
+    empirical_std = float(jnp.std(kernel))
+    assert 0.5 * expected_std < empirical_std < 1.5 * expected_std, (
+        f"kernel std {empirical_std:.3e} not within 0.5x..1.5x He target {expected_std:.3e}"
+    )
+    assert jnp.max(jnp.abs(bias)) <= 1e-3
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_init_paper_override(dtype):
+    """``kernel_init_std=1e-2`` reproduces the paper's PVManifoldMLR recipe."""
+    in_dim, out_dim = 64, 32
+    layer = HypLinearPV(_manifold(dtype), in_dim, out_dim, rngs=nnx.Rngs(42), kernel_init_std=1e-2)
+
+    kernel = layer.kernel[...]
+    assert jnp.max(jnp.abs(kernel)) < 0.1, f"kernel too large for std=1e-2 override: max={jnp.max(jnp.abs(kernel))}"
+
+
 def test_pv_linear_rejects_non_pv_manifold():
     class Fake:
         pass

--- a/tests/nn_layers/test_pv_linear.py
+++ b/tests/nn_layers/test_pv_linear.py
@@ -2,6 +2,7 @@
 
 import jax
 import jax.numpy as jnp
+import optax
 import pytest
 from flax import nnx
 
@@ -299,3 +300,56 @@ def test_pv_linear_identity_at_zero_bias_and_zero_input(dtype):
     y = layer(x, c=1.0)
     atol = 1e-5 if dtype == jnp.float32 else 1e-12
     assert jnp.allclose(y, jnp.zeros_like(y), atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_trains_with_euclidean_adam(dtype):
+    """Euclidean Adam drives an MSE regression loss down on HypLinearPV + HypRegressionPV.
+
+    PV layers expose plain ``nnx.Param`` (not ``ManifoldParam``) because the PV
+    retraction is exact Euclidean addition (paper Sec 4). A vanilla
+    ``optax.adam`` optimizer must therefore be sufficient to train them — no
+    Riemannian wrapper needed. This guards that contract.
+    """
+    from hyperbolix.nn_layers import HypRegressionPV
+
+    batch_size, in_dim, hidden_dim, out_dim = 32, 6, 8, 3
+    manifold = _manifold(dtype)
+    c = 1.0
+
+    key = jax.random.PRNGKey(0)
+    k_x, k_t = jax.random.split(key)
+    x = jax.random.normal(k_x, (batch_size, in_dim), dtype=dtype) * 0.3
+    target = jax.random.normal(k_t, (batch_size, out_dim), dtype=dtype) * 0.5
+
+    class TinyPVModel(nnx.Module):
+        def __init__(self, rngs: nnx.Rngs):
+            self.linear = HypLinearPV(manifold, in_dim, hidden_dim, rngs=rngs)
+            self.head = HypRegressionPV(manifold, hidden_dim, out_dim, rngs=rngs)
+
+        def __call__(self, inputs, curvature):
+            h = self.linear(inputs, c=curvature)
+            return self.head(h, c=curvature)
+
+    model = TinyPVModel(nnx.Rngs(42))
+    optimizer = nnx.Optimizer(model, optax.adam(1e-2), wrt=nnx.Param)
+
+    def loss_fn(m):
+        y = m(x, c)
+        return jnp.mean((y - target) ** 2)
+
+    @nnx.jit
+    def step(m, opt):
+        loss, grads = nnx.value_and_grad(loss_fn)(m)
+        opt.update(m, grads)
+        return loss
+
+    initial_loss = float(loss_fn(model))
+    for _ in range(200):
+        step(model, optimizer)
+    final_loss = float(loss_fn(model))
+
+    assert jnp.isfinite(final_loss)
+    assert final_loss < 0.5 * initial_loss, (
+        f"Euclidean Adam on PV layers failed to reduce MSE: initial={initial_loss:.4f}, final={final_loss:.4f}"
+    )

--- a/tests/nn_layers/test_pv_linear.py
+++ b/tests/nn_layers/test_pv_linear.py
@@ -1,0 +1,265 @@
+"""Tests for HypLinearPV (Proper Velocity FC layer, Chen et al. 2026 Thm 5.3)."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from hyperbolix.manifolds import ProperVelocity
+from hyperbolix.nn_layers import HypLinearPV
+from hyperbolix.nn_layers.pv_linear import _pv_fc_forward
+
+
+def _manifold(dtype: jnp.dtype) -> ProperVelocity:
+    return ProperVelocity(dtype=dtype)
+
+
+def _manifold_points(dtype: jnp.dtype, shape: tuple[int, ...], seed: int = 0) -> jnp.ndarray:
+    """Gaussian samples: valid PV points (PV is unconstrained)."""
+    return jax.random.normal(jax.random.PRNGKey(seed), shape, dtype=dtype) * 0.3
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_forward_shape_and_finite(dtype):
+    batch_size, in_dim, out_dim = 8, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearPV(_manifold(dtype), in_dim, out_dim, rngs=rngs)
+
+    y = layer(x, c=1.0)
+
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+    assert y.dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_output_is_on_manifold(dtype):
+    """PV is unconstrained, so on-manifold reduces to finiteness — but let's confirm."""
+    batch_size, in_dim, out_dim = 8, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+    manifold = _manifold(dtype)
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearPV(manifold, in_dim, out_dim, rngs=rngs)
+    y = layer(x, c=1.0)
+
+    is_on = jax.vmap(manifold.is_in_manifold, in_axes=(0, None))(y, 1.0)
+    assert bool(is_on.all())
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_jitted_forward(dtype):
+    batch_size, in_dim, out_dim = 8, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearPV(_manifold(dtype), in_dim, out_dim, rngs=rngs)
+
+    @nnx.jit
+    def forward(module, inputs, curvature):
+        return module(inputs, c=curvature)
+
+    y = forward(layer, x, 1.0)
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_gradient(dtype):
+    batch_size, in_dim, out_dim = 4, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearPV(_manifold(dtype), in_dim, out_dim, rngs=rngs)
+
+    def loss_fn(model):
+        y = model(x, c=1.0)
+        return jnp.sum(y**2)
+
+    loss, grads = nnx.value_and_grad(loss_fn)(layer)
+
+    assert jnp.isfinite(loss)
+    assert jnp.isfinite(grads.kernel[...]).all()
+    assert jnp.isfinite(grads.bias[...]).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_jitted_gradient(dtype):
+    batch_size, in_dim, out_dim = 4, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearPV(_manifold(dtype), in_dim, out_dim, rngs=rngs)
+
+    @nnx.jit
+    def loss_fn(module, inputs, curvature):
+        y = module(inputs, c=curvature)
+        return jnp.sum(y**2)
+
+    loss, grads = nnx.value_and_grad(lambda model: loss_fn(model, x, 1.0))(layer)
+
+    assert jnp.isfinite(loss)
+    assert jnp.isfinite(grads.kernel[...]).all()
+    assert jnp.isfinite(grads.bias[...]).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_tangent_input(dtype):
+    batch_size, in_dim, out_dim = 8, 5, 3
+    v = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearPV(_manifold(dtype), in_dim, out_dim, rngs=rngs, input_space="tangent")
+
+    y = layer(v, c=1.0)
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_tangent_matches_manual_lift(dtype):
+    """input_space='tangent' must equal manual expmap_0 + input_space='manifold'."""
+    batch_size, in_dim, out_dim = 6, 5, 4
+    v = _manifold_points(dtype, (batch_size, in_dim))
+    manifold = _manifold(dtype)
+
+    manifold_layer = HypLinearPV(manifold, in_dim, out_dim, rngs=nnx.Rngs(7), input_space="manifold")
+    tangent_layer = HypLinearPV(manifold, in_dim, out_dim, rngs=nnx.Rngs(7), input_space="tangent")
+
+    x = jax.vmap(manifold.expmap_0, in_axes=(0, None))(v, 1.0)
+    y_manual = manifold_layer(x, c=1.0)
+    y_tangent = tangent_layer(v, c=1.0)
+
+    atol = 1e-5 if dtype == jnp.float32 else 1e-10
+    assert jnp.allclose(y_manual, y_tangent, atol=atol)
+
+
+@pytest.mark.parametrize("activation", [jax.nn.relu, jnp.tanh])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_inner_activation(dtype, activation):
+    """inner_activation applies inside the outer sinh (paper Eq. 23)."""
+    batch_size, in_dim, out_dim = 4, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearPV(
+        _manifold(dtype),
+        in_dim,
+        out_dim,
+        rngs=rngs,
+        inner_activation=activation,
+    )
+
+    y = layer(x, c=1.0)
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_inner_activation_matches_external(dtype):
+    """Applying inner_activation in-layer must equal manual sigma(v) inside sinh(sqrt_c*sigma(v))/sqrt_c."""
+    batch_size, in_dim, out_dim = 4, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+    manifold = _manifold(dtype)
+    c = 1.0
+
+    base = HypLinearPV(manifold, in_dim, out_dim, rngs=nnx.Rngs(9), input_space="manifold")
+    activated = HypLinearPV(manifold, in_dim, out_dim, rngs=nnx.Rngs(9), input_space="manifold", inner_activation=jnp.tanh)
+
+    # v = compute_mlr(x, kernel, bias, c)
+    v = manifold.compute_mlr(x, base.kernel[...], base.bias[...], c, base.clamping_factor, base.smoothing_factor)
+    sqrt_c = jnp.sqrt(jnp.asarray(c, dtype=v.dtype))
+    expected = jnp.sinh(sqrt_c * jnp.tanh(v)) / sqrt_c
+
+    y = activated(x, c=c)
+    atol = 2e-6 if dtype == jnp.float32 else 1e-12
+    assert jnp.allclose(y, expected, atol=atol)
+
+
+@pytest.mark.parametrize("c", [0.1, 1.0, 2.0])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_different_curvatures(dtype, c):
+    batch_size, in_dim, out_dim = 4, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypLinearPV(_manifold(dtype), in_dim, out_dim, rngs=rngs)
+
+    y = layer(x, c=c)
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_chained_with_regression(dtype):
+    """HypLinearPV output is a valid PV point usable as input to HypRegressionPV."""
+    from hyperbolix.nn_layers import HypRegressionPV
+
+    batch_size, in_dim, hidden_dim, out_dim = 4, 5, 8, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+    manifold = _manifold(dtype)
+
+    linear = HypLinearPV(manifold, in_dim, hidden_dim, rngs=nnx.Rngs(42))
+    regression = HypRegressionPV(manifold, hidden_dim, out_dim, rngs=nnx.Rngs(43))
+
+    h = linear(x, c=1.0)
+    y = regression(h, c=1.0)
+
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(h).all()
+    assert jnp.isfinite(y).all()
+
+
+def test_pv_linear_rejects_bad_input_space():
+    with pytest.raises(ValueError, match="input_space"):
+        HypLinearPV(_manifold(jnp.float32), 3, 2, rngs=nnx.Rngs(0), input_space="nope")
+
+
+def test_pv_linear_rejects_non_pv_manifold():
+    class Fake:
+        pass
+
+    with pytest.raises(TypeError, match="ProperVelocity"):
+        HypLinearPV(Fake(), 3, 2, rngs=nnx.Rngs(0))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_fc_forward_helper_matches_layer(dtype):
+    """The exported _pv_fc_forward helper and HypLinearPV must agree bit-for-bit."""
+    batch_size, in_dim, out_dim = 4, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+    manifold = _manifold(dtype)
+
+    layer = HypLinearPV(manifold, in_dim, out_dim, rngs=nnx.Rngs(11))
+    y_layer = layer(x, c=1.0)
+    y_helper = _pv_fc_forward(
+        x,
+        layer.kernel[...],
+        layer.bias[...],
+        manifold,
+        1.0,
+        "manifold",
+        layer.clamping_factor,
+        layer.smoothing_factor,
+        None,
+    )
+    atol = 1e-6 if dtype == jnp.float32 else 1e-12
+    assert jnp.allclose(y_layer, y_helper, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_linear_identity_at_zero_bias_and_zero_input(dtype):
+    """At x=0 with bias=0, the MLR argument collapses to zero, so y must be zero."""
+    batch_size, in_dim, out_dim = 3, 4, 5
+    manifold = _manifold(dtype)
+    x = jnp.zeros((batch_size, in_dim), dtype=dtype)
+
+    layer = HypLinearPV(manifold, in_dim, out_dim, rngs=nnx.Rngs(3))
+    # Force zero bias.
+    layer.bias = nnx.Param(jnp.zeros_like(layer.bias[...]))
+
+    y = layer(x, c=1.0)
+    atol = 1e-5 if dtype == jnp.float32 else 1e-12
+    assert jnp.allclose(y, jnp.zeros_like(y), atol=atol)

--- a/tests/nn_layers/test_pv_regression.py
+++ b/tests/nn_layers/test_pv_regression.py
@@ -1,0 +1,154 @@
+"""Tests for HypRegressionPV (Proper Velocity MLR layer, Chen et al. 2026)."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from hyperbolix.manifolds import ProperVelocity
+from hyperbolix.nn_layers import HypRegressionPV
+
+
+def _manifold(dtype: jnp.dtype) -> ProperVelocity:
+    return ProperVelocity(dtype=dtype)
+
+
+def _manifold_points(dtype: jnp.dtype, shape: tuple[int, ...], seed: int = 0) -> jnp.ndarray:
+    """Gaussian samples: valid PV points without any projection (PV is unconstrained)."""
+    return jax.random.normal(jax.random.PRNGKey(seed), shape, dtype=dtype) * 0.3
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_regression_forward_shape_and_finite(dtype):
+    batch_size, in_dim, out_dim = 8, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypRegressionPV(_manifold(dtype), in_dim, out_dim, rngs=rngs)
+
+    y = layer(x, c=1.0)
+
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+    assert y.dtype == dtype
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_regression_jitted_forward(dtype):
+    batch_size, in_dim, out_dim = 8, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypRegressionPV(_manifold(dtype), in_dim, out_dim, rngs=rngs)
+
+    @nnx.jit
+    def forward(module, inputs, curvature):
+        return module(inputs, c=curvature)
+
+    y = forward(layer, x, 1.0)
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_regression_gradient(dtype):
+    batch_size, in_dim, out_dim = 4, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypRegressionPV(_manifold(dtype), in_dim, out_dim, rngs=rngs)
+
+    def loss_fn(model):
+        y = model(x, c=1.0)
+        return jnp.sum(y**2)
+
+    loss, grads = nnx.value_and_grad(loss_fn)(layer)
+
+    assert jnp.isfinite(loss)
+    assert jnp.isfinite(grads.kernel[...]).all()
+    assert jnp.isfinite(grads.bias[...]).all()
+    # Non-trivial kernel gradient: at init, bias≈0 and kernel≈0 (std=1e-2), so gradients
+    # should be small but nonzero. We require at least one element to be nonzero.
+    assert jnp.any(jnp.abs(grads.kernel[...]) > 0)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_regression_jitted_gradient(dtype):
+    batch_size, in_dim, out_dim = 4, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypRegressionPV(_manifold(dtype), in_dim, out_dim, rngs=rngs)
+
+    @nnx.jit
+    def loss_fn(module, inputs, curvature):
+        y = module(inputs, c=curvature)
+        return jnp.sum(y**2)
+
+    loss, grads = nnx.value_and_grad(lambda model: loss_fn(model, x, 1.0))(layer)
+
+    assert jnp.isfinite(loss)
+    assert jnp.isfinite(grads.kernel[...]).all()
+    assert jnp.isfinite(grads.bias[...]).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_regression_tangent_input(dtype):
+    """With input_space='tangent', Euclidean input is lifted via expmap_0 inside the layer."""
+    batch_size, in_dim, out_dim = 8, 5, 3
+    v = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypRegressionPV(_manifold(dtype), in_dim, out_dim, rngs=rngs, input_space="tangent")
+
+    y = layer(v, c=1.0)
+
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_regression_tangent_matches_manual_lift(dtype):
+    """input_space='tangent' must equal manual expmap_0 + input_space='manifold'."""
+    batch_size, in_dim, out_dim = 6, 5, 4
+    v = _manifold_points(dtype, (batch_size, in_dim))
+    manifold = _manifold(dtype)
+
+    manifold_layer = HypRegressionPV(manifold, in_dim, out_dim, rngs=nnx.Rngs(7), input_space="manifold")
+    tangent_layer = HypRegressionPV(manifold, in_dim, out_dim, rngs=nnx.Rngs(7), input_space="tangent")
+
+    x = jax.vmap(manifold.expmap_0, in_axes=(0, None))(v, 1.0)
+    y_manual = manifold_layer(x, c=1.0)
+    y_tangent = tangent_layer(v, c=1.0)
+
+    atol = 1e-5 if dtype == jnp.float32 else 1e-10
+    assert jnp.allclose(y_manual, y_tangent, atol=atol)
+
+
+@pytest.mark.parametrize("c", [0.1, 1.0, 2.0])
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_pv_regression_different_curvatures(dtype, c):
+    batch_size, in_dim, out_dim = 4, 5, 3
+    x = _manifold_points(dtype, (batch_size, in_dim))
+
+    rngs = nnx.Rngs(42)
+    layer = HypRegressionPV(_manifold(dtype), in_dim, out_dim, rngs=rngs)
+
+    y = layer(x, c=c)
+    assert y.shape == (batch_size, out_dim)
+    assert jnp.isfinite(y).all()
+
+
+def test_pv_regression_rejects_bad_input_space():
+    with pytest.raises(ValueError, match="input_space"):
+        HypRegressionPV(_manifold(jnp.float32), 3, 2, rngs=nnx.Rngs(0), input_space="nope")
+
+
+def test_pv_regression_rejects_non_pv_manifold():
+    """Validator must reject a non-PV manifold that lacks compute_mlr."""
+
+    class Fake:
+        pass
+
+    with pytest.raises(TypeError, match="ProperVelocity"):
+        HypRegressionPV(Fake(), 3, 2, rngs=nnx.Rngs(0))  # type: ignore[arg-type]

--- a/tests/test_class_based_manifolds.py
+++ b/tests/test_class_based_manifolds.py
@@ -14,6 +14,7 @@ import jax.numpy as jnp
 from hyperbolix.manifolds.euclidean import Euclidean
 from hyperbolix.manifolds.hyperboloid import VERSION_DEFAULT, Hyperboloid
 from hyperbolix.manifolds.poincare import VERSION_MOBIUS_DIRECT, Poincare
+from hyperbolix.manifolds.proper_velocity import ProperVelocity
 
 
 def test_poincare_jit_dist_method():
@@ -453,3 +454,244 @@ def test_bound_method_jit():
 
     assert d.dtype == jnp.float64
     assert jnp.isfinite(d)
+
+
+# ---------------------------------------------------------------------------
+# ProperVelocity: JIT / vmap / grad / dtype
+# ---------------------------------------------------------------------------
+
+
+def test_proper_velocity_jit_dist_method():
+    """Verify that ProperVelocity.dist() is JIT-compilable."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+    x = jnp.array([0.1, 0.2])
+    y = jnp.array([0.3, 0.4])
+
+    dist_jit = jax.jit(manifold.dist)
+    d = dist_jit(x, y, c=1.0)
+
+    assert d.dtype == jnp.float64
+    assert jnp.isfinite(d)
+    assert d > 0
+
+
+def test_proper_velocity_jit_expmap_method():
+    """Verify that ProperVelocity.expmap() is JIT-compilable."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+    v = jnp.array([0.05, 0.05])
+    x = jnp.array([0.1, 0.2])
+
+    expmap_jit = jax.jit(manifold.expmap)
+    result = expmap_jit(v, x, c=1.0)
+
+    assert result.dtype == jnp.float64
+    assert result.shape == (2,)
+    assert jnp.all(jnp.isfinite(result))
+
+
+def test_proper_velocity_jit_logmap_method():
+    """Verify that ProperVelocity.logmap() is JIT-compilable."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+    x = jnp.array([0.1, 0.2])
+    y = jnp.array([0.3, 0.4])
+
+    logmap_jit = jax.jit(manifold.logmap)
+    result = logmap_jit(y, x, c=1.0)
+
+    assert result.dtype == jnp.float64
+    assert result.shape == (2,)
+    assert jnp.all(jnp.isfinite(result))
+
+
+def test_proper_velocity_jit_no_recompilation_same_instance():
+    """Verify same PV instance doesn't trigger recompilation."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+    dist_jit = jax.jit(manifold.dist)
+
+    x1 = jnp.array([0.1, 0.2])
+    y1 = jnp.array([0.3, 0.4])
+    d1 = dist_jit(x1, y1, c=1.0)
+
+    x2 = jnp.array([0.15, 0.25])
+    y2 = jnp.array([0.35, 0.45])
+    d2 = dist_jit(x2, y2, c=1.0)
+
+    assert d1.dtype == jnp.float64
+    assert d2.dtype == jnp.float64
+    assert jnp.isfinite(d1)
+    assert jnp.isfinite(d2)
+    assert not jnp.allclose(d1, d2)
+
+
+def test_proper_velocity_vmap_dist_method():
+    """Verify that ProperVelocity.dist() works with vmap."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+    x_batch = jnp.array([[0.1, 0.2], [0.15, 0.25]])
+    y_batch = jnp.array([[0.3, 0.4], [0.35, 0.45]])
+
+    dist_batched = jax.vmap(manifold.dist, in_axes=(0, 0, None))
+    distances = dist_batched(x_batch, y_batch, 1.0)
+
+    assert distances.shape == (2,)
+    assert distances.dtype == jnp.float64
+    assert jnp.all(jnp.isfinite(distances))
+    assert jnp.all(distances > 0)
+
+
+def test_proper_velocity_vmap_expmap_method():
+    """Verify that ProperVelocity.expmap() works with vmap."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+    v_batch = jnp.array([[0.05, 0.05], [0.06, 0.06]])
+    x_batch = jnp.array([[0.1, 0.2], [0.15, 0.25]])
+
+    expmap_batched = jax.vmap(manifold.expmap, in_axes=(0, 0, None))
+    results = expmap_batched(v_batch, x_batch, 1.0)
+
+    assert results.shape == (2, 2)
+    assert results.dtype == jnp.float64
+    assert jnp.all(jnp.isfinite(results))
+
+
+def test_proper_velocity_vmap_jit_combined():
+    """Verify that PV vmap and JIT compose."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+    x_batch = jnp.array([[0.1, 0.2], [0.15, 0.25]])
+    y_batch = jnp.array([[0.3, 0.4], [0.35, 0.45]])
+
+    @jax.jit
+    def compute_dists(x, y):
+        return jax.vmap(manifold.dist, in_axes=(0, 0, None))(x, y, 1.0)
+
+    distances = compute_dists(x_batch, y_batch)
+    assert distances.shape == (2,)
+    assert distances.dtype == jnp.float64
+    assert jnp.all(jnp.isfinite(distances))
+
+
+def test_proper_velocity_grad_through_dist():
+    """Verify gradients flow through ProperVelocity.dist()."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+
+    def loss_fn(x):
+        y = jnp.array([0.3, 0.4])
+        return manifold.dist(x, y, c=1.0)
+
+    x = jnp.array([0.1, 0.2])
+    grad = jax.grad(loss_fn)(x)
+
+    assert grad.shape == (2,)
+    assert grad.dtype == jnp.float64
+    assert jnp.all(jnp.isfinite(grad))
+    assert jnp.linalg.norm(grad) > 0
+
+
+def test_proper_velocity_grad_through_expmap():
+    """Verify gradients flow through ProperVelocity.expmap()."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+
+    def loss_fn(v):
+        x = jnp.array([0.1, 0.2])
+        y = manifold.expmap(v, x, c=1.0)
+        return jnp.sum(y**2)
+
+    v = jnp.array([0.05, 0.05])
+    grad = jax.grad(loss_fn)(v)
+
+    assert grad.shape == (2,)
+    assert grad.dtype == jnp.float64
+    assert jnp.all(jnp.isfinite(grad))
+
+
+def test_proper_velocity_grad_through_logmap():
+    """Verify gradients flow through ProperVelocity.logmap()."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+
+    def loss_fn(y):
+        x = jnp.array([0.1, 0.2])
+        v = manifold.logmap(y, x, c=1.0)
+        return jnp.sum(v**2)
+
+    y = jnp.array([0.3, 0.4])
+    grad = jax.grad(loss_fn)(y)
+
+    assert grad.shape == (2,)
+    assert grad.dtype == jnp.float64
+    assert jnp.all(jnp.isfinite(grad))
+
+
+def test_proper_velocity_grad_through_addition():
+    """Verify gradients flow through ProperVelocity.addition()."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+
+    def loss_fn(x):
+        y = jnp.array([0.3, 0.4])
+        return jnp.sum(manifold.addition(x, y, c=1.0) ** 2)
+
+    x = jnp.array([0.1, 0.2])
+    grad = jax.grad(loss_fn)(x)
+
+    assert grad.shape == (2,)
+    assert grad.dtype == jnp.float64
+    assert jnp.all(jnp.isfinite(grad))
+    assert jnp.linalg.norm(grad) > 0
+
+
+def test_proper_velocity_value_and_grad():
+    """Verify value_and_grad works with PV methods."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+
+    def loss_fn(x):
+        y = jnp.array([0.3, 0.4])
+        return manifold.dist(x, y, c=1.0)
+
+    x = jnp.array([0.1, 0.2])
+    value, grad = jax.value_and_grad(loss_fn)(x)
+
+    assert value.shape == ()
+    assert value.dtype == jnp.float64
+    assert grad.shape == (2,)
+    assert grad.dtype == jnp.float64
+
+
+def test_proper_velocity_dtype_casting_float32_to_float64():
+    """Verify float32 arrays are cast to float64 when using float64 PV manifold."""
+    manifold = ProperVelocity(dtype=jnp.float64)
+    x = jnp.array([0.1, 0.2], dtype=jnp.float32)
+    y = jnp.array([0.3, 0.4], dtype=jnp.float32)
+
+    d = manifold.dist(x, y, c=1.0)
+    assert d.dtype == jnp.float64
+
+
+def test_proper_velocity_dtype_casting_preserves_float32():
+    """Verify float32 PV manifold preserves float32."""
+    manifold = ProperVelocity(dtype=jnp.float32)
+    x = jnp.array([0.1, 0.2], dtype=jnp.float32)
+    y = jnp.array([0.3, 0.4], dtype=jnp.float32)
+
+    d = manifold.dist(x, y, c=1.0)
+    assert d.dtype == jnp.float32
+
+
+def test_proper_velocity_cross_dtype_jit_compiles_per_dtype():
+    """Verify PV JIT compiles separately per dtype and values match."""
+    pv_f32 = ProperVelocity(dtype=jnp.float32)
+    pv_f64 = ProperVelocity(dtype=jnp.float64)
+
+    x = jnp.array([0.1, 0.2])
+    y = jnp.array([0.3, 0.4])
+
+    @jax.jit
+    def dist_f32(x, y):
+        return pv_f32.dist(x, y, c=1.0)
+
+    @jax.jit
+    def dist_f64(x, y):
+        return pv_f64.dist(x, y, c=1.0)
+
+    d_f32 = dist_f32(x, y)
+    d_f64 = dist_f64(x, y)
+
+    assert d_f32.dtype == jnp.float32
+    assert d_f64.dtype == jnp.float64
+    assert jnp.allclose(d_f32, d_f64, rtol=1e-5)

--- a/tests/test_manifolds.py
+++ b/tests/test_manifolds.py
@@ -63,6 +63,15 @@ def _is_hyperboloid(manifold) -> bool:
     return isinstance(manifold, hj.manifolds.Hyperboloid)
 
 
+def _is_pv(manifold) -> bool:
+    return isinstance(manifold, hj.manifolds.ProperVelocity)
+
+
+def _is_gyrovector(manifold) -> bool:
+    """Manifolds that carry a gyrovector-space structure (non-trivial scalar mul axioms)."""
+    return _is_euclidean(manifold) or _is_poincare(manifold) or _is_pv(manifold)
+
+
 # ---------------------------------------------------------------------------
 # Tests
 
@@ -153,7 +162,7 @@ def test_scalar_mul(
     manifold, c = manifold_and_c
     atol, rtol = tolerance
 
-    if _is_poincare(manifold) and uniform_points.dtype == jnp.dtype("float32"):
+    if (_is_poincare(manifold) or _is_pv(manifold)) and uniform_points.dtype == jnp.dtype("float32"):
         rtol = max(rtol, 2e-2)
 
     # Create scalars - now as 1D array since scalar_mul expects scalar per point
@@ -178,8 +187,8 @@ def test_scalar_mul(
     result4 = scalar_mul_batch(r2 * r1, uniform_points, c)
     assert jnp.allclose(result2, result4, atol=atol, rtol=rtol)
 
-    # Additional properties for Euclidean and PoincareBall (not Hyperboloid)
-    if _is_euclidean(manifold) or _is_poincare(manifold):
+    # Additional gyrovector properties (Euclidean, Poincaré, PV — not Hyperboloid)
+    if _is_gyrovector(manifold):
         # N-Gyroaddition property: n ⊗ x = x ⊕ x ⊕ ... ⊕ x (n times)
         n = rng.integers(3, 10)
         n_sum = jnp.zeros_like(uniform_points)
@@ -256,7 +265,7 @@ def test_scalar_mul(
     assert jnp.allclose(res[1:], jnp.zeros_like(res[1:]), atol=atol, rtol=rtol)
 
     # Stability of multiplication with large scalars
-    if _is_euclidean(manifold) or _is_poincare(manifold):
+    if _is_gyrovector(manifold):
         # Note: Hyperboloid manifold may fail is_in_manifold check with large scalars
         # due to numerical instabilities in the Minkowski inner product
         r_large_arr = jnp.ones(uniform_points.shape[0]) * r_large
@@ -285,9 +294,11 @@ def test_gyration(
     """
     manifold, c = manifold_and_c
 
-    # The gyration operation is only defined for the PoincareBall manifold
-    if _is_euclidean(manifold) or _is_hyperboloid(manifold):
-        pytest.skip("Gyration operation not defined for Euclidean/Hyperboloid manifold")
+    # The gyration operation is only defined for the PoincareBall manifold here
+    # (PV has its own, distinct gyration algebra; we don't exercise it via the
+    # Möbius _gyration helper used in this test).
+    if _is_euclidean(manifold) or _is_hyperboloid(manifold) or _is_pv(manifold):
+        pytest.skip("Möbius gyration test only defined for PoincareBall manifold")
 
     atol, rtol = tolerance
     x, y, z, a = _split(uniform_points, 4)
@@ -461,8 +472,9 @@ def test_expmap_logmap_basic(
     else:
         origin = jnp.zeros_like(uniform_points)
 
-    # Create random tangent vectors
-    bound = 10
+    # Create random tangent vectors. PV has no tanh-like saturation in expmap,
+    # so sinh(√c·||v||) overflows for large bounds — use a smaller range there.
+    bound = 1.0 if _is_pv(manifold) else 10
     v = jnp.asarray(rng.uniform(-bound, bound, size=uniform_points.shape), dtype=uniform_points.dtype)
     v0 = v.copy()
 
@@ -475,7 +487,7 @@ def test_expmap_logmap_basic(
     assert _batch_is_in_tangent_space(manifold, v0, origin, c)
 
     # Numerical stability of expmap/expmap_0/retraction
-    if _is_euclidean(manifold) or _is_poincare(manifold):
+    if _is_gyrovector(manifold):
         # Note: Hyperboloid may fail is_in_manifold check due to numerical errors
 
         # Expmap
@@ -496,7 +508,7 @@ def test_expmap_logmap_basic(
         assert jnp.all(jnp.isfinite(v0_retr))
 
     # Numerical stability of logmap - check logmap produces finite tangent vectors
-    if _is_poincare(manifold) and uniform_points.dtype == jnp.dtype("float32"):
+    if (_is_poincare(manifold) or _is_pv(manifold)) and uniform_points.dtype == jnp.dtype("float32"):
         rtol = max(rtol, 3e-2)
 
     logmap_y_x = logmap_batch(y, x, c)
@@ -665,7 +677,7 @@ def test_tangent_norm_consistency(manifold_and_c, tolerance: tuple[float, float]
     # near boundary. When points approach ||x|| ≈ 1/√c, the conformal factor λ(x) = 2/(1-c||x||²)
     # can exceed 10,000. The logmap/tangent_norm round-trip (divide by λ, then multiply by λ)
     # loses precision, especially for large distances (>10) involving near-boundary points.
-    if _is_poincare(manifold) and uniform_points.dtype == jnp.dtype("float32"):
+    if (_is_poincare(manifold) or _is_pv(manifold)) and uniform_points.dtype == jnp.dtype("float32"):
         rtol = max(rtol, 5e-2)
 
     # Consistency of tangent_norm with logmap and dist
@@ -715,3 +727,9 @@ def test_is_in_manifold(manifold_and_c, uniform_points: jnp.ndarray) -> None:
         # Points not on hyperboloid surface should not be on manifold
         outside = jnp.ones_like(uniform_points[0]) * 10.0
         assert not manifold.is_in_manifold(outside, c=c)
+    elif _is_pv(manifold):
+        # PV is unconstrained: only non-finite points are off-manifold.
+        nan_point = uniform_points[0].at[0].set(jnp.nan)
+        assert not bool(manifold.is_in_manifold(nan_point, c=c))
+        inf_point = uniform_points[0].at[0].set(jnp.inf)
+        assert not bool(manifold.is_in_manifold(inf_point, c=c))

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -5,8 +5,10 @@ import jax.numpy as jnp
 
 from hyperbolix.manifolds import hyperboloid as hyperboloid_module
 from hyperbolix.manifolds import poincare as poincare_module
+from hyperbolix.manifolds import proper_velocity as proper_velocity_module
 from hyperbolix.manifolds.hyperboloid import Hyperboloid
 from hyperbolix.manifolds.poincare import Poincare
+from hyperbolix.manifolds.proper_velocity import ProperVelocity
 
 
 class TestPoincareClassConstants:
@@ -23,6 +25,11 @@ class TestPoincareClassConstants:
         assert hasattr(hyperboloid_module, "VERSION_DEFAULT")
         assert hasattr(hyperboloid_module, "VERSION_SMOOTHENED")
         assert hasattr(hyperboloid_module, "MIN_NORM")
+
+    def test_proper_velocity_module_constants(self):
+        """Verify PV constants are available from module."""
+        assert hasattr(proper_velocity_module, "VERSION_DEFAULT")
+        assert hasattr(proper_velocity_module, "MIN_NORM")
 
 
 class TestPoincarePrecision:
@@ -98,6 +105,76 @@ class TestHyperboloidPrecision:
         assert result.dtype == jnp.float64
 
 
+class TestProperVelocityPrecision:
+    """Test auto-casting for Proper Velocity operations."""
+
+    def test_dist_float64_output(self):
+        manifold = ProperVelocity(dtype=jnp.float64)
+        x = jnp.array([0.1, 0.2])  # float32
+        y = jnp.array([0.3, 0.4])  # float32
+        d = manifold.dist(x, y, c=1.0)
+        assert d.dtype == jnp.float64
+
+    def test_proj_float64_output(self):
+        manifold = ProperVelocity(dtype=jnp.float64)
+        x = jnp.array([0.9, 0.1])  # float32
+        result = manifold.proj(x, c=1.0)
+        assert result.dtype == jnp.float64
+
+    def test_expmap_float64_output(self):
+        manifold = ProperVelocity(dtype=jnp.float64)
+        v = jnp.array([0.1, 0.2])
+        x = jnp.array([0.05, 0.05])
+        result = manifold.expmap(v, x, c=1.0)
+        assert result.dtype == jnp.float64
+
+    def test_logmap_float64_output(self):
+        manifold = ProperVelocity(dtype=jnp.float64)
+        x = jnp.array([0.1, 0.2])
+        y = jnp.array([0.3, 0.4])
+        result = manifold.logmap(y, x, c=1.0)
+        assert result.dtype == jnp.float64
+
+    def test_addition_float64_output(self):
+        manifold = ProperVelocity(dtype=jnp.float64)
+        x = jnp.array([0.1, 0.2])
+        y = jnp.array([0.05, 0.05])
+        result = manifold.addition(x, y, c=1.0)
+        assert result.dtype == jnp.float64
+
+    def test_scalar_mul_float64_output(self):
+        manifold = ProperVelocity(dtype=jnp.float64)
+        x = jnp.array([0.1, 0.2])
+        result = manifold.scalar_mul(0.5, x, c=1.0)
+        assert result.dtype == jnp.float64
+
+    def test_ptransp_float64_output(self):
+        manifold = ProperVelocity(dtype=jnp.float64)
+        v = jnp.array([0.05, 0.05])
+        x = jnp.array([0.1, 0.2])
+        y = jnp.array([0.3, 0.4])
+        result = manifold.ptransp(v, x, y, c=1.0)
+        assert result.dtype == jnp.float64
+
+    def test_tangent_inner_float64_output(self):
+        manifold = ProperVelocity(dtype=jnp.float64)
+        u = jnp.array([0.1, 0.2])
+        v = jnp.array([0.05, 0.05])
+        x = jnp.array([0.2, 0.3])
+        result = manifold.tangent_inner(u, v, x, c=1.0)
+        assert result.dtype == jnp.float64
+
+    def test_dist_values_match(self):
+        """Verify class version produces same values as manual casting."""
+        manifold = ProperVelocity(dtype=jnp.float64)
+        x = jnp.array([0.1, 0.2])
+        y = jnp.array([0.3, 0.4])
+
+        d_class = manifold.dist(x, y, c=1.0)
+        d_manual = proper_velocity_module._dist(x.astype(jnp.float64), y.astype(jnp.float64), c=1.0)
+        assert jnp.allclose(d_class, d_manual)
+
+
 class TestVmapJitCompat:
     """Test that class-based manifolds work with jax.vmap and jax.jit."""
 
@@ -148,6 +225,26 @@ class TestVmapJitCompat:
         assert distances.shape == (2,)
         assert distances.dtype == jnp.float64
 
+    def test_vmap_proper_velocity_dist(self):
+        manifold = ProperVelocity(dtype=jnp.float64)
+        x_batch = jnp.array([[0.1, 0.2], [0.15, 0.25]])
+        y_batch = jnp.array([[0.3, 0.4], [0.35, 0.45]])
+
+        dist_fn = jax.vmap(manifold.dist, in_axes=(0, 0, None))
+        distances = dist_fn(x_batch, y_batch, 1.0)
+
+        assert distances.shape == (2,)
+        assert distances.dtype == jnp.float64
+
+    def test_jit_proper_velocity_dist(self):
+        manifold = ProperVelocity(dtype=jnp.float64)
+        x = jnp.array([0.1, 0.2])
+        y = jnp.array([0.3, 0.4])
+
+        dist_jit = jax.jit(manifold.dist)
+        d = dist_jit(x, y, c=1.0)
+        assert d.dtype == jnp.float64
+
 
 class TestMLRFunctions:
     """Test that MLR functions work correctly via class methods."""
@@ -181,6 +278,19 @@ class TestMLRFunctions:
         x = jax.random.normal(k1, (4, 4))  # batch=4, in_dim=4 (ambient)
         x = jax.vmap(manifold.proj, in_axes=(0, None))(x, 1.0)
         z = jax.random.normal(k2, (5, 3)) * 0.1  # out_dim=5, in_dim-1=3
+        r = jax.random.normal(k3, (5, 1)) * 0.01
+
+        result = manifold.compute_mlr(x, z, r, c=1.0, clamping_factor=1.0, smoothing_factor=50.0)
+        assert result.shape == (4, 5)
+        assert jnp.all(jnp.isfinite(result))
+        assert result.dtype == jnp.float64
+
+    def test_proper_velocity_compute_mlr(self):
+        manifold = ProperVelocity(dtype=jnp.float64)
+        key = jax.random.PRNGKey(0)
+        k1, k2, k3 = jax.random.split(key, 3)
+        x = jax.random.normal(k1, (4, 3)) * 0.3  # batch=4, in_dim=3
+        z = jax.random.normal(k2, (5, 3)) * 0.1  # out_dim=5, in_dim=3 (PV has no time coord)
         r = jax.random.normal(k3, (5, 1)) * 0.01
 
         result = manifold.compute_mlr(x, z, r, c=1.0, clamping_factor=1.0, smoothing_factor=50.0)

--- a/tests/test_pv_manifold.py
+++ b/tests/test_pv_manifold.py
@@ -1,0 +1,606 @@
+"""Proper Velocity manifold tests.
+
+Covers the invariants required for a gyrovector-space / Riemannian-manifold
+implementation: gyroaddition and scalar multiplication identities, distance
+metric properties, exp/log inverse, parallel-transport round-trip, tangent
+inner product structure, and numerical stability at large radii.
+
+Uses ``dtype``, ``tolerance``, ``rng``, ``seed_jax`` from ``tests/conftest.py``
+and local PV-only fixtures here so the shared ``manifold_and_c`` fixture is
+not affected.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import hyperbolix.manifolds.proper_velocity as pv_impl
+from hyperbolix.manifolds import ProperVelocity
+
+# ---------------------------------------------------------------------------
+# Fixtures (local to PV tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", params=[0.1, 0.5, 1.0, 2.0], ids=lambda c: f"c{c}")
+def curvature(request: pytest.FixtureRequest) -> float:
+    """Positive curvature parameter c (sectional curvature = -c)."""
+    return float(request.param)
+
+
+@pytest.fixture(scope="module")
+def pv_manifold(dtype: jnp.dtype) -> ProperVelocity:
+    """Fresh PV manifold with the dtype fixture's precision."""
+    return ProperVelocity(dtype=dtype)
+
+
+@pytest.fixture(scope="module", params=[2, 5, 10], ids=lambda d: f"dim{d}")
+def dim(request: pytest.FixtureRequest) -> int:
+    return int(request.param)
+
+
+@pytest.fixture(scope="module")
+def pv_points(dim: int, dtype: jnp.dtype, rng: np.random.Generator) -> jnp.ndarray:
+    """Batch of PV points sampled as Gaussians in R^n. PV is unconstrained, so no projection."""
+    num_pts = 256
+    np_dtype = np.dtype(dtype.name)
+    data = rng.normal(0.0, 1.0, size=(num_pts, dim)).astype(np_dtype)
+    return jnp.asarray(data)
+
+
+@pytest.fixture(scope="module")
+def pv_tangent_vectors(dim: int, dtype: jnp.dtype, rng: np.random.Generator) -> jnp.ndarray:
+    """Random tangent vectors (any R^n vector is tangent in PV)."""
+    num_pts = 256
+    np_dtype = np.dtype(dtype.name)
+    data = rng.normal(0.0, 1.0, size=(num_pts, dim)).astype(np_dtype) * 0.3
+    return jnp.asarray(data)
+
+
+def _split(points: jnp.ndarray, parts: int) -> tuple[jnp.ndarray, ...]:
+    """Split into ``parts`` equal-size chunks (truncates remainder for vmap compatibility)."""
+    chunk = points.shape[0] // parts
+    return tuple(points[i * chunk : (i + 1) * chunk] for i in range(parts))
+
+
+# ---------------------------------------------------------------------------
+# Gyroaddition
+# ---------------------------------------------------------------------------
+
+
+def test_pv_gyroaddition_identity(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+) -> None:
+    """0 ⊕ x = x  and  x ⊕ 0 = x."""
+    atol, rtol = tolerance
+    add = jax.vmap(pv_manifold.addition, in_axes=(0, 0, None))
+    zero = jnp.zeros_like(pv_points)
+
+    left = add(zero, pv_points, curvature)
+    assert jnp.allclose(left, pv_points, atol=atol, rtol=rtol)
+
+    right = add(pv_points, zero, curvature)
+    assert jnp.allclose(right, pv_points, atol=atol, rtol=rtol)
+
+
+def test_pv_gyroaddition_inverse(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+) -> None:
+    """(-x) ⊕ x = 0  and  x ⊕ (-x) = 0."""
+    atol, rtol = tolerance
+    add = jax.vmap(pv_manifold.addition, in_axes=(0, 0, None))
+    zero = jnp.zeros_like(pv_points)
+
+    lhs = add(-pv_points, pv_points, curvature)
+    assert jnp.allclose(lhs + 1.0, zero + 1.0, atol=atol, rtol=rtol)
+
+    rhs = add(pv_points, -pv_points, curvature)
+    assert jnp.allclose(rhs + 1.0, zero + 1.0, atol=atol, rtol=rtol)
+
+
+# ---------------------------------------------------------------------------
+# Scalar multiplication
+# ---------------------------------------------------------------------------
+
+
+def test_pv_scalar_mul_identity_and_zero(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+) -> None:
+    """0 ⊗ x = 0 and 1 ⊗ x = x."""
+    atol, rtol = tolerance
+    scalar_mul = jax.vmap(pv_manifold.scalar_mul, in_axes=(0, 0, None))
+
+    ones = jnp.ones(pv_points.shape[0], dtype=pv_points.dtype)
+    zeros = jnp.zeros_like(ones)
+
+    identity_result = scalar_mul(ones, pv_points, curvature)
+    assert jnp.allclose(identity_result, pv_points, atol=atol, rtol=rtol)
+
+    zero_result = scalar_mul(zeros, pv_points, curvature)
+    assert jnp.allclose(zero_result + 1.0, jnp.ones_like(pv_points), atol=atol, rtol=rtol)
+
+
+def test_pv_scalar_mul_associative(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+    rng: np.random.Generator,
+) -> None:
+    """(r₁·r₂) ⊗ x = r₁ ⊗ (r₂ ⊗ x)."""
+    atol, rtol = tolerance
+    # Float32 PV at moderate curvature needs a loose rtol because sinh(·asinh(·))
+    # compounds rounding error for large |t|.
+    if pv_points.dtype == jnp.dtype("float32"):
+        rtol = max(rtol, 2e-2)
+
+    scalar_mul = jax.vmap(pv_manifold.scalar_mul, in_axes=(0, 0, None))
+
+    r1 = jnp.asarray(rng.uniform(-1.5, 1.5, pv_points.shape[0]), dtype=pv_points.dtype)
+    r2 = jnp.asarray(rng.uniform(-1.5, 1.5, pv_points.shape[0]), dtype=pv_points.dtype)
+
+    lhs = scalar_mul(r1 * r2, pv_points, curvature)
+    rhs = scalar_mul(r1, scalar_mul(r2, pv_points, curvature), curvature)
+    assert jnp.allclose(lhs, rhs, atol=atol, rtol=rtol)
+
+
+# ---------------------------------------------------------------------------
+# Distance
+# ---------------------------------------------------------------------------
+
+
+def test_pv_dist_symmetry_and_identity(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+) -> None:
+    """d(x, y) = d(y, x) and d(x, x) = 0."""
+    atol, rtol = tolerance
+    dist = jax.vmap(pv_manifold.dist, in_axes=(0, 0, None))
+
+    x, y = _split(pv_points, 2)
+
+    d_xy = dist(x, y, curvature)
+    d_yx = dist(y, x, curvature)
+    assert jnp.allclose(d_xy, d_yx, atol=atol, rtol=rtol)
+    assert jnp.all(d_xy >= -atol)
+
+    d_xx = dist(x, x, curvature)
+    assert jnp.allclose(d_xx, jnp.zeros_like(d_xx), atol=atol, rtol=rtol)
+
+
+def test_pv_dist_triangle_inequality(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+) -> None:
+    """d(x, z) ≤ d(x, y) + d(y, z)."""
+    atol, _ = tolerance
+    dist = jax.vmap(pv_manifold.dist, in_axes=(0, 0, None))
+
+    x, y, z = _split(pv_points, 3)
+    d_xz = dist(x, z, curvature)
+    d_xy = dist(x, y, curvature)
+    d_yz = dist(y, z, curvature)
+    assert jnp.all(d_xz <= d_xy + d_yz + 10.0 * atol)
+
+
+def test_pv_dist_0_matches_dist_to_origin(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+) -> None:
+    """dist_0(x) = dist(x, 0)."""
+    atol, rtol = tolerance
+    dist = jax.vmap(pv_manifold.dist, in_axes=(0, 0, None))
+    dist_0 = jax.vmap(pv_manifold.dist_0, in_axes=(0, None))
+
+    origin = jnp.zeros_like(pv_points)
+
+    d1 = dist_0(pv_points, curvature)
+    d2 = dist(pv_points, origin, curvature)
+    assert jnp.allclose(d1, d2, atol=atol, rtol=rtol)
+
+
+# ---------------------------------------------------------------------------
+# Exponential / logarithmic maps
+# ---------------------------------------------------------------------------
+
+
+def test_pv_expmap_0_logmap_0_inverse(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+) -> None:
+    """exp_0(log_0(x)) = x."""
+    atol, rtol = tolerance
+    if pv_points.dtype == jnp.dtype("float32"):
+        rtol = max(rtol, 1e-2)
+    logmap_0 = jax.vmap(pv_manifold.logmap_0, in_axes=(0, None))
+    expmap_0 = jax.vmap(pv_manifold.expmap_0, in_axes=(0, None))
+
+    v = logmap_0(pv_points, curvature)
+    x_reconstructed = expmap_0(v, curvature)
+    assert jnp.allclose(x_reconstructed, pv_points, atol=atol, rtol=rtol)
+
+
+def test_pv_logmap_0_expmap_0_inverse(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_tangent_vectors: jnp.ndarray,
+) -> None:
+    """log_0(exp_0(v)) = v, for reasonable tangent norms."""
+    atol, rtol = tolerance
+    if pv_tangent_vectors.dtype == jnp.dtype("float32"):
+        rtol = max(rtol, 1e-2)
+    logmap_0 = jax.vmap(pv_manifold.logmap_0, in_axes=(0, None))
+    expmap_0 = jax.vmap(pv_manifold.expmap_0, in_axes=(0, None))
+
+    y = expmap_0(pv_tangent_vectors, curvature)
+    v_reconstructed = logmap_0(y, curvature)
+    assert jnp.allclose(v_reconstructed, pv_tangent_vectors, atol=atol, rtol=rtol)
+
+
+def test_pv_expmap_logmap_inverse(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+    pv_tangent_vectors: jnp.ndarray,
+) -> None:
+    """log_x(exp_x(v)) = v (away from the origin)."""
+    atol, rtol = tolerance
+    if pv_points.dtype == jnp.dtype("float32"):
+        rtol = max(rtol, 3e-2)
+    expmap = jax.vmap(pv_manifold.expmap, in_axes=(0, 0, None))
+    logmap = jax.vmap(pv_manifold.logmap, in_axes=(0, 0, None))
+
+    y = expmap(pv_tangent_vectors, pv_points, curvature)
+    v_reconstructed = logmap(y, pv_points, curvature)
+    assert jnp.allclose(v_reconstructed, pv_tangent_vectors, atol=atol, rtol=rtol)
+
+
+def test_pv_expmap_matches_expmap_0_at_origin(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_tangent_vectors: jnp.ndarray,
+) -> None:
+    """expmap(v, 0) = expmap_0(v)."""
+    atol, rtol = tolerance
+    expmap = jax.vmap(pv_manifold.expmap, in_axes=(0, 0, None))
+    expmap_0 = jax.vmap(pv_manifold.expmap_0, in_axes=(0, None))
+
+    origin = jnp.zeros_like(pv_tangent_vectors)
+    out_general = expmap(pv_tangent_vectors, origin, curvature)
+    out_origin = expmap_0(pv_tangent_vectors, curvature)
+    assert jnp.allclose(out_general, out_origin, atol=atol, rtol=rtol)
+
+
+def test_pv_logmap_matches_logmap_0_at_origin(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+) -> None:
+    """logmap(y, 0) = logmap_0(y)."""
+    atol, rtol = tolerance
+    logmap = jax.vmap(pv_manifold.logmap, in_axes=(0, 0, None))
+    logmap_0 = jax.vmap(pv_manifold.logmap_0, in_axes=(0, None))
+
+    origin = jnp.zeros_like(pv_points)
+    out_general = logmap(pv_points, origin, curvature)
+    out_origin = logmap_0(pv_points, curvature)
+    assert jnp.allclose(out_general, out_origin, atol=atol, rtol=rtol)
+
+
+# ---------------------------------------------------------------------------
+# Parallel transport
+# ---------------------------------------------------------------------------
+
+
+def test_pv_ptransp_0_matches_ptransp_from_origin(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+    pv_tangent_vectors: jnp.ndarray,
+) -> None:
+    """PT_{0→y}(v) = PT_{x=0, y}(v)."""
+    atol, rtol = tolerance
+    ptransp = jax.vmap(pv_manifold.ptransp, in_axes=(0, 0, 0, None))
+    ptransp_0 = jax.vmap(pv_manifold.ptransp_0, in_axes=(0, 0, None))
+
+    origin = jnp.zeros_like(pv_points)
+    via_general = ptransp(pv_tangent_vectors, origin, pv_points, curvature)
+    via_zero = ptransp_0(pv_tangent_vectors, pv_points, curvature)
+    assert jnp.allclose(via_general, via_zero, atol=atol, rtol=rtol)
+
+
+def test_pv_ptransp_0_round_trip(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+    pv_tangent_vectors: jnp.ndarray,
+) -> None:
+    """PT_{y→0} ∘ PT_{0→y}(v) = v."""
+    atol, rtol = tolerance
+    if pv_points.dtype == jnp.dtype("float32"):
+        rtol = max(rtol, 2e-2)
+    ptransp = jax.vmap(pv_manifold.ptransp, in_axes=(0, 0, 0, None))
+    ptransp_0 = jax.vmap(pv_manifold.ptransp_0, in_axes=(0, 0, None))
+
+    origin = jnp.zeros_like(pv_points)
+
+    forward = ptransp_0(pv_tangent_vectors, pv_points, curvature)
+    back = ptransp(forward, pv_points, origin, curvature)
+    assert jnp.allclose(back, pv_tangent_vectors, atol=atol, rtol=rtol)
+
+
+def test_pv_ptransp_preserves_tangent_norm(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+    pv_tangent_vectors: jnp.ndarray,
+) -> None:
+    """‖PT_{0→y}(v)‖_y = ‖v‖_0."""
+    atol, rtol = tolerance
+    if pv_points.dtype == jnp.dtype("float32"):
+        rtol = max(rtol, 2e-2)
+    ptransp_0 = jax.vmap(pv_manifold.ptransp_0, in_axes=(0, 0, None))
+    tangent_norm = jax.vmap(pv_manifold.tangent_norm, in_axes=(0, 0, None))
+
+    origin = jnp.zeros_like(pv_points)
+
+    norm_at_origin = tangent_norm(pv_tangent_vectors, origin, curvature)
+    transported = ptransp_0(pv_tangent_vectors, pv_points, curvature)
+    norm_at_y = tangent_norm(transported, pv_points, curvature)
+    assert jnp.allclose(norm_at_origin, norm_at_y, atol=atol, rtol=rtol)
+
+
+# ---------------------------------------------------------------------------
+# Tangent inner product
+# ---------------------------------------------------------------------------
+
+
+def test_pv_tangent_inner_symmetric(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+    pv_tangent_vectors: jnp.ndarray,
+    rng: np.random.Generator,
+) -> None:
+    """g_x(u, v) = g_x(v, u)."""
+    atol, rtol = tolerance
+    tangent_inner = jax.vmap(pv_manifold.tangent_inner, in_axes=(0, 0, 0, None))
+
+    u = pv_tangent_vectors
+    v = jnp.asarray(
+        rng.normal(0.0, 1.0, size=u.shape).astype(np.dtype(u.dtype.name)) * 0.3,
+        dtype=u.dtype,
+    )
+
+    inner_uv = tangent_inner(u, v, pv_points, curvature)
+    inner_vu = tangent_inner(v, u, pv_points, curvature)
+    assert jnp.allclose(inner_uv, inner_vu, atol=atol, rtol=rtol)
+
+
+def test_pv_tangent_inner_positive_definite(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    pv_points: jnp.ndarray,
+    pv_tangent_vectors: jnp.ndarray,
+) -> None:
+    """g_x(v, v) > 0 for nonzero v."""
+    tangent_inner = jax.vmap(pv_manifold.tangent_inner, in_axes=(0, 0, 0, None))
+
+    inner = tangent_inner(pv_tangent_vectors, pv_tangent_vectors, pv_points, curvature)
+    # Discard any accidentally-zero rows.
+    norms = jnp.linalg.norm(pv_tangent_vectors, axis=-1)
+    nonzero = norms > 0.0
+    assert jnp.all(inner[nonzero] > 0)
+
+
+def test_pv_tangent_norm_equals_dist(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+) -> None:
+    """‖log_x(y)‖_x = d(x, y)."""
+    atol, rtol = tolerance
+    if pv_points.dtype == jnp.dtype("float32"):
+        rtol = max(rtol, 3e-2)
+    logmap = jax.vmap(pv_manifold.logmap, in_axes=(0, 0, None))
+    tangent_norm = jax.vmap(pv_manifold.tangent_norm, in_axes=(0, 0, None))
+    dist = jax.vmap(pv_manifold.dist, in_axes=(0, 0, None))
+
+    x, y = _split(pv_points, 2)
+    v = logmap(y, x, curvature)
+    lhs = tangent_norm(v, x, curvature)
+    rhs = dist(x, y, curvature)
+    assert jnp.allclose(lhs, rhs, atol=atol, rtol=rtol)
+
+
+def test_pv_egrad2rgrad_is_metric_dual(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+    pv_tangent_vectors: jnp.ndarray,
+    rng: np.random.Generator,
+) -> None:
+    """⟨grad, v⟩ = g_x(egrad2rgrad(grad), v) for all v."""
+    atol, rtol = tolerance
+    if pv_points.dtype == jnp.dtype("float32"):
+        rtol = max(rtol, 5e-3)
+    egrad2rgrad = jax.vmap(pv_manifold.egrad2rgrad, in_axes=(0, 0, None))
+    tangent_inner = jax.vmap(pv_manifold.tangent_inner, in_axes=(0, 0, 0, None))
+
+    grad = jnp.asarray(
+        rng.normal(0.0, 1.0, size=pv_points.shape).astype(np.dtype(pv_points.dtype.name)),
+        dtype=pv_points.dtype,
+    )
+    rgrad = egrad2rgrad(grad, pv_points, curvature)
+
+    euclid_inner = jnp.sum(grad * pv_tangent_vectors, axis=-1)
+    riem_inner = tangent_inner(rgrad, pv_tangent_vectors, pv_points, curvature)
+    assert jnp.allclose(euclid_inner, riem_inner, atol=atol, rtol=rtol)
+
+
+# ---------------------------------------------------------------------------
+# Validation / projection
+# ---------------------------------------------------------------------------
+
+
+def test_pv_is_in_manifold_finite_inputs(pv_manifold: ProperVelocity, curvature: float, pv_points: jnp.ndarray) -> None:
+    """Finite points are in the manifold; NaN/Inf points are not."""
+    is_in = jax.vmap(pv_manifold.is_in_manifold, in_axes=(0, None))
+    assert bool(jnp.all(is_in(pv_points, curvature)))
+
+    # A point with NaN must fail validation.
+    bad = pv_points[0].at[0].set(jnp.nan)
+    assert not bool(pv_manifold.is_in_manifold(bad, curvature))
+
+    bad_inf = pv_points[0].at[0].set(jnp.inf)
+    assert not bool(pv_manifold.is_in_manifold(bad_inf, curvature))
+
+
+def test_pv_proj_is_identity_on_finite_inputs(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_points: jnp.ndarray,
+) -> None:
+    """proj(x) = x whenever x is finite; NaN rows are scrubbed to 0."""
+    atol, rtol = tolerance
+    proj = jax.vmap(pv_manifold.proj, in_axes=(0, None))
+    projected = proj(pv_points, curvature)
+    assert jnp.allclose(projected, pv_points, atol=atol, rtol=rtol)
+
+    dim = pv_points.shape[1]
+    nan_row = jnp.full((dim,), jnp.nan, dtype=pv_points.dtype)
+    cleaned = pv_manifold.proj(nan_row, curvature)
+    assert jnp.all(jnp.isfinite(cleaned))
+
+
+# ---------------------------------------------------------------------------
+# Closed-form checks against paper Thm 4.3 (simplified at origin)
+# ---------------------------------------------------------------------------
+
+
+def test_pv_matches_paper_thm_4_3_at_origin(
+    pv_manifold: ProperVelocity,
+    curvature: float,
+    tolerance: tuple[float, float],
+    pv_tangent_vectors: jnp.ndarray,
+) -> None:
+    """At x = 0, Eq. 10-13 collapse to the simple asinh/sinh forms.
+
+    Eq. 10 with x = 0 gives exp_0(v) = sinh(√c·||v||)·v/(√c·||v||).
+    Eq. 13 with x = 0 gives d(0, y) = (1/√c)·asinh(√c·||y||).
+    """
+    atol, rtol = tolerance
+    sqrt_c = float(np.sqrt(curvature))
+
+    # Expected exp_0(v) from Thm 4.3 simplified form.
+    v = pv_tangent_vectors
+    v_norm = jnp.linalg.norm(v, axis=-1, keepdims=True)
+    v_norm_safe = jnp.maximum(v_norm, 1e-12)
+    expected_exp = jnp.sinh(sqrt_c * v_norm_safe) * v / (sqrt_c * v_norm_safe)
+
+    expmap_0 = jax.vmap(pv_manifold.expmap_0, in_axes=(0, None))
+    got_exp = expmap_0(v, curvature)
+    assert jnp.allclose(got_exp, expected_exp, atol=atol, rtol=rtol)
+
+    # Expected d(0, y) from Thm 4.3 simplified form.
+    y = pv_tangent_vectors  # any finite R^n batch works
+    y_norm = jnp.linalg.norm(y, axis=-1)
+    expected_dist = jnp.asinh(sqrt_c * y_norm) / sqrt_c
+
+    dist_0 = jax.vmap(pv_manifold.dist_0, in_axes=(0, None))
+    got_dist = dist_0(y, curvature)
+    assert jnp.allclose(got_dist, expected_dist, atol=atol, rtol=rtol)
+
+
+# ---------------------------------------------------------------------------
+# Numerical stability at large radii
+# ---------------------------------------------------------------------------
+
+
+def test_pv_stability_at_large_norms(pv_manifold: ProperVelocity, curvature: float) -> None:
+    """PV claims float32 stability up to large ‖x‖ — check finiteness up to 100.
+
+    Paper Tables 1-2 claim PV operators remain finite where Poincaré's gradient
+    vanishes and Hyperboloid's explodes. This guards that claim in our port.
+    """
+    # Build a ray of points with norms up to 100.
+    dim = 8
+    radii = jnp.asarray([0.0, 1.0, 5.0, 20.0, 50.0, 100.0], dtype=pv_manifold.dtype)
+    unit = jnp.zeros((radii.shape[0], dim), dtype=pv_manifold.dtype).at[:, 0].set(1.0)
+    pts = unit * radii[:, None]
+
+    dist_0 = jax.vmap(pv_manifold.dist_0, in_axes=(0, None))
+    logmap_0 = jax.vmap(pv_manifold.logmap_0, in_axes=(0, None))
+    expmap_0 = jax.vmap(pv_manifold.expmap_0, in_axes=(0, None))
+
+    d = dist_0(pts, curvature)
+    assert jnp.all(jnp.isfinite(d))
+
+    v = logmap_0(pts, curvature)
+    assert jnp.all(jnp.isfinite(v))
+
+    reconstructed = expmap_0(v, curvature)
+    assert jnp.all(jnp.isfinite(reconstructed))
+
+
+# ---------------------------------------------------------------------------
+# Cross-check: private helpers
+# ---------------------------------------------------------------------------
+
+
+def test_pv_beta_matches_formula(curvature: float, pv_points: jnp.ndarray) -> None:
+    """β_x = 1/√(1 + c·‖x‖²)."""
+    sqnorm = jnp.sum(pv_points**2, axis=-1)
+    expected = 1.0 / jnp.sqrt(1.0 + curvature * sqnorm)
+    got = jax.vmap(pv_impl._beta, in_axes=(0, None))(pv_points, curvature)
+    assert jnp.allclose(got, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_pv_dpi_norm_identity(curvature: float, pv_points: jnp.ndarray, pv_tangent_vectors: jnp.ndarray) -> None:
+    """((1+β_x)/β_x)² · ‖dπ_x(v)‖² = g_x(v, v).
+
+    This identity underlies the simplified expmap form; if it fails, the
+    closed-form expmap is wrong by a scalar factor.
+    """
+    beta = jax.vmap(pv_impl._beta, in_axes=(0, None))(pv_points, curvature)
+    dpi = jax.vmap(pv_impl._dpi_x, in_axes=(0, 0, None))(pv_points, pv_tangent_vectors, curvature)
+    dpi_sqnorm = jnp.sum(dpi**2, axis=-1)
+
+    scale = ((1.0 + beta) / beta) ** 2
+    lhs = scale * dpi_sqnorm
+
+    xv = jnp.sum(pv_points * pv_tangent_vectors, axis=-1)
+    rhs = jnp.sum(pv_tangent_vectors**2, axis=-1) - curvature * beta**2 * xv**2
+
+    assert jnp.allclose(lhs, rhs, atol=1e-4, rtol=1e-4)


### PR DESCRIPTION
## Summary
- Added ProperVelocity section to docs/api-reference/manifolds.md with mkdocstrings directive and usage examples
- Added HypLinearPV, HypConv2DPV, HypRegressionPV sections to docs/api-reference/nn-layers.md with comparison tables and end-to-end example
- Updated feature counts: 3→4 manifolds, 13+→20+ layers, 4→5 activations
- Updated changelog and references in docs/index.md, docs/getting-started.md, README.md

🤖 Generated with Claude Code