### PR TITLE
docs: Self-host MathJax + add CI external-host allowlist guard

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,14 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --dev
 
+      - name: Vendor MathJax (pinned + integrity-checked, self-hosted)
+        run: uv run python scripts/vendor_mathjax.py
+
       - name: Build documentation
         run: uv run mkdocs build --strict
+
+      - name: Audit external resource hosts
+        run: uv run python scripts/check_external_hosts.py site
 
       - name: Upload documentation artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ wheels/
 
 # Docs
 site/
+# MathJax is vendored at build time by scripts/vendor_mathjax.py (not committed)
+docs/javascripts/mathjax/
 
 # Benchmark results
 results/

--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,27 @@
+// MathJax configuration for MkDocs Material + pymdownx.arithmatex (generic mode).
+//
+// The document$.subscribe(...) hook re-typesets math after Material's
+// `navigation.instant` page swaps. Without it, equations only render on the
+// first full page load and appear as raw \(...\) after client-side navigation.
+//
+// Loaded BEFORE the engine (see extra_javascript order in mkdocs.yml) so that
+// window.MathJax is defined when tex-mml-chtml.js initialises.
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true,
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex",
+  },
+};
+
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache();
+  MathJax.typesetClear();
+  MathJax.texReset();
+  MathJax.typesetPromise();
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,7 +87,8 @@ markdown_extensions:
       toc_depth: 3
 
 extra_javascript:
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  - javascripts/mathjax.js
+  - javascripts/mathjax/tex-mml-chtml.js  # self-hosted, vendored by scripts/vendor_mathjax.py
 
 extra_css:
   - stylesheets/extra.css

--- a/scripts/check_external_hosts.py
+++ b/scripts/check_external_hosts.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Fail the docs build if the rendered site loads a resource from a host
+outside the allowlist.
+
+Guards against supply-chain CDN references (e.g. the ``polyfill.io`` incident)
+silently re-entering the documentation. Only *resource loads* are enforced —
+``<script src>``, ``<link href>``, ``<img src>``, and CSS ``url()`` / ``@import`` —
+because those execute or style the page. Plain ``<a href>`` links (citations,
+external references) are intentionally ignored, so prose never trips the guard.
+
+Usage:
+    python scripts/check_external_hosts.py site
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+
+# Third-party hosts the docs may load resources from at runtime.
+# Keep this MINIMAL: every entry is a domain your readers' browsers must trust.
+ALLOWED_HOSTS: frozenset[str] = frozenset(
+    {
+        "fonts.googleapis.com",  # Material theme web-font stylesheet
+        "fonts.gstatic.com",  # Material theme web-font files
+        # "cdn.jsdelivr.net",  # MathJax — keep ONLY if not self-hosting via vendor_mathjax.py
+    }
+)
+
+# Your own GitHub Pages host(s): absolute self-links are not third parties.
+SELF_HOSTS: frozenset[str] = frozenset({"timoklein.github.io", "hyperbolix.github.io"})
+
+_HOST_RE = re.compile(r"https?://([^/\"'\s)]+)", re.IGNORECASE)
+# CSS url(...) and @import targets, inside <style> blocks and .css files.
+_CSS_URL_RE = re.compile(r"""(?:url\(|@import\s+)['"]?\s*(https?://[^/\"'\s)]+)""", re.IGNORECASE)
+
+
+class _ResourceHostCollector(HTMLParser):
+    """Collects external hosts from resource-loading tags only (not <a href>)."""
+
+    _RESOURCE_ATTR = {
+        "script": "src",
+        "link": "href",
+        "img": "src",
+        "source": "src",
+        "iframe": "src",
+        "embed": "src",
+        "object": "data",
+    }
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.hosts: set[str] = set()
+        self._in_style = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "style":
+            self._in_style = True
+        attr = self._RESOURCE_ATTR.get(tag)
+        if attr is None:
+            return
+        for name, value in attrs:
+            if name == attr and value:
+                match = _HOST_RE.match(value)
+                if match:
+                    self.hosts.add(match.group(1).lower())
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "style":
+            self._in_style = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_style:
+            self.hosts |= _hosts_in_css(data)
+
+
+def _hosts_in_css(text: str) -> set[str]:
+    hosts: set[str] = set()
+    for match in _CSS_URL_RE.finditer(text):
+        host = _HOST_RE.match(match.group(1))
+        if host:
+            hosts.add(host.group(1).lower())
+    return hosts
+
+
+def _hosts_in_html(text: str) -> set[str]:
+    parser = _ResourceHostCollector()
+    parser.feed(text)
+    return parser.hosts
+
+
+def find_violations(site_dir: Path, allowed: frozenset[str]) -> dict[str, set[str]]:
+    """Map each offending file -> set of disallowed external hosts it loads."""
+    permitted = allowed | SELF_HOSTS
+    violations: dict[str, set[str]] = {}
+    for path in site_dir.rglob("*"):
+        if path.suffix == ".html":
+            found = _hosts_in_html(path.read_text(encoding="utf-8", errors="ignore"))
+        elif path.suffix == ".css":
+            found = _hosts_in_css(path.read_text(encoding="utf-8", errors="ignore"))
+        else:
+            continue
+        bad = {host for host in found if host not in permitted}
+        if bad:
+            violations[str(path.relative_to(site_dir))] = bad
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    site_dir = Path(argv[1]) if len(argv) > 1 else Path("site")
+    if not site_dir.is_dir():
+        print(f"error: '{site_dir}' is not a directory (run `mkdocs build` first)", file=sys.stderr)
+        return 2
+
+    violations = find_violations(site_dir, ALLOWED_HOSTS)
+    if not violations:
+        print(f"✓ external-host audit passed (allowed: {sorted(ALLOWED_HOSTS)})")
+        return 0
+
+    print("✗ external-host audit FAILED — disallowed resource hosts found:\n", file=sys.stderr)
+    offenders: set[str] = set()
+    for file, hosts in sorted(violations.items()):
+        offenders |= hosts
+        print(f"  {file}: {', '.join(sorted(hosts))}", file=sys.stderr)
+    print(
+        f"\n{len(offenders)} disallowed host(s): {', '.join(sorted(offenders))}\n"
+        "If a host is intentional, add it to ALLOWED_HOSTS in "
+        "scripts/check_external_hosts.py. Otherwise remove the reference.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/vendor_mathjax.py
+++ b/scripts/vendor_mathjax.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Vendor a pinned, integrity-checked MathJax build into docs/javascripts/mathjax/.
+
+Downloads the exact MathJax release from the npm registry, verifies its
+SHA-512 integrity hash, and extracts the self-contained ``es5/`` bundle
+(JS engine + CHTML web fonts) so the documentation loads MathJax from our
+own domain with **zero third-party CDN at runtime**.
+
+This exists because the docs previously loaded MathJax (and a now-hostile
+``polyfill.io`` shim) from a CDN. Self-hosting removes the supply-chain and
+CDN-trust surface entirely; pinning the hash makes the build tamper-evident.
+
+Run before ``mkdocs build`` / ``mkdocs serve``:
+
+    uv run python scripts/vendor_mathjax.py
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import shutil
+import sys
+import tarfile
+import urllib.request
+from pathlib import Path
+
+MATHJAX_VERSION = "3.2.2"
+# From: curl -s https://registry.npmjs.org/mathjax/3.2.2 \
+#   | python3 -c "import json,sys; print(json.load(sys.stdin)['dist']['integrity'])"
+# This is the part AFTER "sha512-". Bump it whenever MATHJAX_VERSION changes.
+EXPECTED_SHA512_B64 = "Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw=="
+
+DEST = Path("docs/javascripts/mathjax")
+PREFIX = "package/es5/"  # the self-contained engine + fonts live under es5/ in the npm tarball
+
+
+def main() -> int:
+    url = f"https://registry.npmjs.org/mathjax/-/mathjax-{MATHJAX_VERSION}.tgz"
+    print(f"Fetching {url}")
+    data = urllib.request.urlopen(url, timeout=60).read()  # noqa: S310 (https URL, hash-verified below)
+
+    digest = base64.b64encode(hashlib.sha512(data).digest()).decode()
+    if digest != EXPECTED_SHA512_B64:
+        print(
+            f"INTEGRITY MISMATCH — refusing to vendor:\n  expected sha512-{EXPECTED_SHA512_B64}\n  got      sha512-{digest}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if DEST.exists():
+        shutil.rmtree(DEST)
+    DEST.mkdir(parents=True)
+
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        members = []
+        for member in tar.getmembers():
+            if not member.name.startswith(PREFIX):
+                continue
+            member.name = member.name[len(PREFIX) :]  # strip "package/es5/"
+            if member.name:
+                members.append(member)
+        # filter="data" (Python 3.12+) rejects path traversal / unsafe members.
+        tar.extractall(DEST, members=members, filter="data")
+
+    print(f"Vendored MathJax {MATHJAX_VERSION} -> {DEST} ({len(members)} files)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_docs_security.py
+++ b/tests/test_docs_security.py
@@ -1,0 +1,41 @@
+"""Guard-rail test: the external-host audit must flag disallowed resource hosts
+(e.g. a re-introduced polyfill.io CDN) while ignoring plain anchor links.
+
+Loads scripts/check_external_hosts.py by path since scripts/ is not a package.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_checker() -> ModuleType:
+    path = Path(__file__).parent.parent / "scripts" / "check_external_hosts.py"
+    spec = importlib.util.spec_from_file_location("check_external_hosts", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_flags_external_script_but_not_anchor_links(tmp_path: Path) -> None:
+    checker = _load_checker()
+    (tmp_path / "index.html").write_text(
+        '<script src="https://polyfill.io/v3/polyfill.min.js"></script>'  # disallowed resource
+        '<script src="https://fonts.googleapis.com/x.js"></script>'  # allowlisted resource
+        '<a href="https://arxiv.org/abs/1805.09112">citation</a>'  # link -> must be ignored
+    )
+    violations = checker.find_violations(tmp_path, checker.ALLOWED_HOSTS)
+    assert violations == {"index.html": {"polyfill.io"}}
+
+
+def test_clean_site_passes(tmp_path: Path) -> None:
+    checker = _load_checker()
+    (tmp_path / "page.html").write_text(
+        '<script src="javascripts/mathjax/tex-mml-chtml.js"></script>'  # relative -> same origin
+        '<link rel="stylesheet" href="https://fonts.googleapis.com/css">'  # allowlisted
+        '<link rel="canonical" href="https://timoklein.github.io/hyperbolix/">'  # self host
+    )
+    assert checker.find_violations(tmp_path, checker.ALLOWED_HOSTS) == {}


### PR DESCRIPTION
## What & why

The hosted docs loaded MathJax — and, until the previous commit, a now-hostile `polyfill.io` shim — from a third-party CDN. This PR removes the CDN trust surface for MathJax entirely and adds a CI guard so a `polyfill.io`-style reference can't silently return.

Follows up on the polyfill.io removal (`5c5b32a` on `main` + the `gh-pages` scrub).

## Changes

**Self-host MathJax**
- `scripts/vendor_mathjax.py` — fetches MathJax 3.2.2 from the npm registry, verifies its **SHA-512** integrity, and extracts the self-contained `es5/` bundle (engine + CHTML web fonts + local SRE speech-rule maps) into `docs/javascripts/mathjax/`. Gitignored; regenerated in CI.
- `docs/javascripts/mathjax.js` — MathJax config for `arithmatex` + a `document$` re-typeset hook. **Also fixes a latent bug:** with `navigation.instant`, math previously only rendered on the first full page load (raw `\(...\)` after client-side nav).
- `mkdocs.yml` — loads the self-hosted engine instead of `cdn.jsdelivr.net`.

**CI allowlist guard**
- `scripts/check_external_hosts.py` — scans the built `site/` for external **resource loads** (`<script src>`, `<link href>`, `<img src>`, CSS `url()`/`@import`) and fails on any host outside a minimal allowlist. Plain `<a href>` citation links are ignored.
- `tests/test_docs_security.py` — proves the guard flags `polyfill.io` and passes a clean site.
- `.github/workflows/docs.yml` — `vendor → build → audit`. Runs on PRs too, so a bad host fails CI before merge.

## Local verification
- `vendor_mathjax.py`: downloaded + hash-verified MathJax 3.2.2 (106 files: 1.2 MB engine + 23 CHTML fonts + 13 SRE maps).
- `mkdocs build --strict`: passes.
- `check_external_hosts.py site`: ✓ only `fonts.googleapis.com` / `fonts.gstatic.com`.
- planted bad host → audit exits `1`.
- `pytest tests/test_docs_security.py`: 2 passed.

## Net effect
| | External hosts readers' browsers contact for resources |
|---|---|
| before | `polyfill.io` ⚠️, `cdn.jsdelivr.net`, `fonts.googleapis.com`, `fonts.gstatic.com` |
| after | `fonts.googleapis.com`, `fonts.gstatic.com` (allowlisted; guard blocks any new host) |

## Known residual (non-issue)
The vendored MathJax JS contains an inert `jsdelivr.net/npm/sre-mathmaps-ie` string — MathJax's **Internet-Explorer-only** speech-map fallback. The modern-browser path uses the locally-vendored `sre/mathmaps/*.json`, so no real reader triggers a CDN fetch.

## Possible follow-ups (not in this PR)
- Material's `privacy` plugin can self-host the Google Fonts too → zero external hosts, allowlist collapses to `{}`.
- Optionally SHA-pin GitHub Actions (`@<sha>` instead of `@v4`) against a tag-repointing compromise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
