### PR TITLE
refactor: Rename HypConv2DHyperboloidPP to HypConv2DHyperboloidILNN with ILNN improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Manifold methods (`dist`, `expmap`, `logmap`, `proj`, `ptransp`) operate on **si
 
 - FGG layers: default `lorentz_kaiming` init with `std = sqrt(1/in_features)` using **ambient** dimensions (not spatial). FGGLinear default `0.5*eye` with bias `0.5`
 - FHCNN/HTC layers: small uniform `U(-0.02, 0.02)`
-- HypLinearHyperboloidPLFC: small normal `std = 0.02`, gyro-bias zeros (Shi et al. 2026 PLFC reference init); `kernel_init_std=1.0` recovers the old HNN++-style init. HypConv2DHyperboloidPP keeps standard normal `std = 1.0` (Shimizu et al. 2020)
+- HypLinearHyperboloidPLFC and HypConv2DHyperboloidILNN: small normal `std = 0.02`, gyro-bias zeros (Shi et al. 2026 PLFC reference init); `kernel_init_std=1.0` recovers the old HNN++-style init (Shimizu et al. 2020). The ILNN conv (formerly HypConv2DHyperboloidPP) is the Shi et al. 2026 Lorentz convolution: LogCat (`log_radius_concat`) + PLFC, with origin padding (`pad_mode="origin"`)
 - Poincare layers: scaled normal `std = (2 * in_dim * out_dim)^{-0.5}` (van Spengler et al. 2023)
 - Standard inits (He, Xavier) are too large for hyperbolic layers
 

--- a/docs/api-reference/nn-layers.md
+++ b/docs/api-reference/nn-layers.md
@@ -108,7 +108,7 @@ print(output.shape)  # (10, 16)
       show_source: true
       heading_level: 4
 
-::: hyperbolix.nn_layers.HypConv2DHyperboloidPP
+::: hyperbolix.nn_layers.HypConv2DHyperboloidILNN
     options:
       show_source: true
       heading_level: 4
@@ -263,11 +263,12 @@ h_eval = jax.nn.relu(h_eval)
 
 `FGGConv2D` combines HCat patch extraction with `FGGLinear` for channel mixing. Unlike `HypConv2DHyperboloid`, it uses the FGG spacelike-V construction, achieving linear growth of hyperbolic distance rather than logarithmic. Supports manifold-origin padding (`pad_mode="origin"`) matching the reference implementation.
 
-| Feature | FGGConv2D | HypConv2DHyperboloid | HypConv2DHyperboloidPP |
+| Feature | FGGConv2D | HypConv2DHyperboloid | HypConv2DHyperboloidILNN |
 |---------|-----------|----------------------|------------------------|
 | **Linear layer** | FGGLinear (V-matrix) | HypLinearHyperboloidFHCNN | HypLinearHyperboloidPLFC (MLR) |
+| **Patch concatenation** | HCat | HCat | LogCat (log-radius-preserving) |
 | **Distance growth** | Linear | Logarithmic | Logarithmic |
-| **Default padding** | Manifold origin | Edge replication | Edge replication |
+| **Default padding** | Manifold origin | Edge replication | Manifold origin |
 | **Weight norm** | Optional (`use_weight_norm`) | No | No |
 
 ### Proper Velocity Convolution (Chen et al. 2026)
@@ -298,13 +299,13 @@ LorentzConv2D provides a simpler, more efficient alternative to HCat-based convo
 
 **Key Differences from HypConv2DHyperboloid:**
 
-| Feature | HypConv2DHyperboloid (HCat+FHCNN) | HypConv2DHyperboloidPP (HCat+HNN++) | LorentzConv2D (HRC) |
+| Feature | HypConv2DHyperboloid (HCat+FHCNN) | HypConv2DHyperboloidILNN (LogCat+PLFC) | LorentzConv2D (HRC) |
 |---------|-----------------------------------|--------------------------------------|-------------------|
-| **Method** | HCat + FHCNN linear | HCat + MLR + sinh diffeomorphism | Euclidean conv on space components |
+| **Method** | HCat + FHCNN linear | LogCat + PLFC (MLR + sinh diffeomorphism) | Euclidean conv on space components |
 | **Dimension** | Grows: `(d-1)×N+1` | Grows: `(d-1)×N+1` | Preserved |
 | **Speed** | Slower (~80s/epoch) | Similar to FHCNN | **2.5x faster** (~32s/epoch) |
-| **Accuracy** | Higher (~71% on MNIST) | Better gradient flow (HNN++) | Lower (~46% on MNIST) |
-| **Use Case** | HCat accuracy | Deep HCat networks | Speed/memory efficiency |
+| **Accuracy** | Higher (~71% on MNIST) | Intrinsic Lorentz conv (Shi et al. 2026) | Lower (~46% on MNIST) |
+| **Use Case** | HCat accuracy | Deep intrinsic Lorentz networks | Speed/memory efficiency |
 
 **Theoretical Connection:**
 
@@ -352,11 +353,11 @@ print(output.shape)  # (8, 14, 14, 65) - dimensions preserved!
     - Working with resource-constrained environments
     - Acceptable accuracy trade-off for 2.5x speedup
 
-    Choose HypConv2DHyperboloid or HypConv2DHyperboloidPP when:
+    Choose HypConv2DHyperboloid or HypConv2DHyperboloidILNN when:
 
     - Maximum accuracy is required
     - Willing to accept slower training and dimensional growth
-    - Use HypConv2DHyperboloidPP for deeper networks (better gradient flow via HNN++)
+    - Use HypConv2DHyperboloidILNN for deeper networks (intrinsic Lorentz conv: LogCat + PLFC, Shi et al. 2026)
 
 ## Hypformer Components
 
@@ -1305,7 +1306,7 @@ print(output.shape)  # (32, 10)
 The neural network layers implement methods from:
 
 - **Ganea et al. (2018)**: "Hyperbolic Neural Networks" - Poincaré linear layers and activations
-- **Shimizu et al. (2020)**: "Hyperbolic Neural Networks++" - Enhanced Poincaré and Hyperboloid operations (`HypLinearPoincarePP`, `HypLinearHyperboloidPLFC`, `HypConv2DHyperboloidPP`)
+- **Shimizu et al. (2020)**: "Hyperbolic Neural Networks++" - Enhanced Poincaré operations and the linearized-kernel conv formulation (`HypLinearPoincarePP`; basis of `HypLinearHyperboloidPLFC` and `HypConv2DHyperboloidILNN`)
 - **Bdeir et al. (2023)**: "Fully Hyperbolic Convolutional Neural Networks for Computer Vision" - HCat-based convolutions (`HypConv2DHyperboloid`)
 - **Chen et al. (2022)**: "Fully Hyperbolic Neural Networks" - FHCNN linear layers
 - **LResNet (2023)**: "Lorentzian ResNet" - HRC-based convolutions (`LorentzConv2D`)
@@ -1316,7 +1317,7 @@ The neural network layers implement methods from:
 - **Chen et al. (2025)**: "Hyperbolic VQ-VAE (HVQ-VAE)" - `HypVQEmbeddingPoincare`; Poincaré-ball codebook with geodesic nearest-neighbour selection and copy-gradient STE
 - **Goswami et al. (2025)**: "HyperVQ" - `HypVQMLRPoincare`; vector quantization as Poincaré-MLR classification with Gumbel-Softmax straight-through selection
 - **Bu et al. (2026)**: "GGBall: Graph Generative Model on Poincaré Ball" - hyperbolic-EMA codebook update and weighted gyromidpoint (`ema_update`, `poincare_weighted_midpoint`)
-- **Shi et al. (2026)**: "Intrinsic Lorentz Neural Network" (ICLR 2026) - point-to-hyperplane Lorentz FC layer with output-side score guard and intrinsic gyro-bias (`HypLinearHyperboloidPLFC`), log-radius concatenation (`Hyperboloid.log_radius_concat`), Lorentz gyroaddition (`Hyperboloid.addition`)
+- **Shi et al. (2026)**: "Intrinsic Lorentz Neural Network" (ICLR 2026, arXiv:2602.23981) - point-to-hyperplane Lorentz FC layer with output-side score guard and intrinsic gyro-bias (`HypLinearHyperboloidPLFC`), log-radius concatenation (`Hyperboloid.log_radius_concat`), Lorentz convolution via LogCat + PLFC with origin padding (`HypConv2DHyperboloidILNN`), Lorentz gyroaddition (`Hyperboloid.addition`)
 
 ### Key Theoretical Connections
 

--- a/docs/user-guide/nn-layers.md
+++ b/docs/user-guide/nn-layers.md
@@ -29,7 +29,8 @@ tables below collapse this into per-task decisions.
 | Layer | Manifold | When to pick |
 |---|---|---|
 | `HypConv2DHyperboloid` | Hyperboloid | **Default** for hyperboloid conv — well-established HCat formulation, robust across configurations |
-| `HypConv2DHyperboloidPP` / `HypConv2DHyperboloidFHNN` | Hyperboloid | Variants of the HCat conv following specific paper formulations (HNN++, FHNN); reach for these when reproducing those papers |
+| `HypConv2DHyperboloidILNN` | Hyperboloid | Intrinsic Lorentz conv (Shi et al. 2026) — log-radius-preserving concatenation (LogCat) + PLFC channel mixing, origin padding, optional gyro-bias |
+| `HypConv2DHyperboloidFHNN` | Hyperboloid | HCat conv following the FHNN paper formulation; reach for it when reproducing that paper |
 | `FGGConv2D` | Hyperboloid | Advanced — HCat expressiveness with FGG's speed, but inherits FGG's init sensitivity |
 | `HypConv2DPoincare` | Poincaré | Standard for Poincaré CNNs (no faster variant exists) |
 | `HypConv2DPV` | Proper Velocity | PV CNNs — raw Euclidean patch concatenation, no β-scaling |

--- a/hyperbolix/nn_layers/__init__.py
+++ b/hyperbolix/nn_layers/__init__.py
@@ -19,7 +19,13 @@ from .hyperboloid_attention import (
     HyperbolicSoftmaxAttention,
     focus_transform,
 )
-from .hyperboloid_conv import FGGConv2D, HypConv2DHyperboloid, HypConv2DHyperboloidFHNN, HypConv2DHyperboloidPP, LorentzConv2D
+from .hyperboloid_conv import (
+    FGGConv2D,
+    HypConv2DHyperboloid,
+    HypConv2DHyperboloidFHNN,
+    HypConv2DHyperboloidILNN,
+    LorentzConv2D,
+)
 from .hyperboloid_core import (
     build_spacelike_V,
     hrc,
@@ -61,7 +67,7 @@ __all__ = [
     "HTCLinear",
     "HypConv2DHyperboloid",
     "HypConv2DHyperboloidFHNN",
-    "HypConv2DHyperboloidPP",
+    "HypConv2DHyperboloidILNN",
     "HypConv2DPV",
     "HypConv2DPoincare",
     "HypLinearHyperboloidFHCNN",

--- a/hyperbolix/nn_layers/hyperboloid_conv.py
+++ b/hyperbolix/nn_layers/hyperboloid_conv.py
@@ -817,18 +817,25 @@ class FGGConv2D(nnx.Module):
         return linear_out_NC.reshape(batch, out_h, out_w, self.out_channels)
 
 
-class HypConv2DHyperboloidPP(nnx.Module):
+class HypConv2DHyperboloidILNN(nnx.Module):
     """
-    Hyperbolic Neural Networks ++ 2D convolutional layer (Hyperboloid model).
+    Intrinsic Lorentz Neural Network (ILNN) 2D convolutional layer (Hyperboloid model).
 
-    Uses HCat (Lorentz direct concatenation) to combine receptive field points,
-    then applies the HNN++ linear transform (MLR + sinh diffeomorphism) for
-    channel mixing.
+    Implements the Lorentz convolution of Shi et al. 2026, Eq. (11):
+    ``y = PLFC(LogCat({x_patch}))``. Receptive-field points are combined with the
+    log-radius-preserving concatenation (LogCat) and mixed across channels by the
+    PLFC linear transform (MLR scores -> sinh diffeomorphism -> time
+    reconstruction). This extends the HNN++ linearized-kernel convolution
+    (Shimizu et al. 2020) by replacing the Euclidean FC and naive concatenation
+    with their intrinsic Lorentz counterparts. Formerly named
+    ``HypConv2DHyperboloidPP``.
 
     Computation steps:
-        1) Extract receptive field (kernel_size x kernel_size) of hyperbolic points
-        2) Apply HCat (Lorentz direct concatenation) to combine receptive field points
-        3) Pass through HNN++ linear (MLR scores -> sinh -> time reconstruction)
+        1) Extract receptive field (kernel_size x kernel_size) of hyperbolic points,
+           padding with the manifold origin if needed
+        2) Apply LogCat (log-radius-preserving concatenation) to combine receptive field points
+        3) Pass through PLFC linear (MLR scores -> guard -> sinh -> time reconstruction)
+        4) Optionally add an intrinsic gyro-bias ``y <- y (+) exp_0([0, b])``
 
     Parameters
     ----------
@@ -846,6 +853,11 @@ class HypConv2DHyperboloidPP(nnx.Module):
         Stride of the convolution (default: 1)
     padding : str
         Padding mode, either 'SAME' or 'VALID' (default: 'SAME')
+    pad_mode : str
+        How to fill padding pixels for 'SAME' padding: ``"origin"`` fills with the
+        manifold origin ``(sqrt(1/c), 0, ..., 0)`` (matching the Shi et al. 2026
+        reference, which clamps zero-padded times up to ``sqrt(1/c)``), ``"edge"``
+        replicates border values (default: ``"origin"``).
     input_space : str
         Type of the input tensor, either 'tangent' or 'manifold' (default: 'manifold').
         Note: This is a static configuration - changing it after initialization requires recompilation.
@@ -857,6 +869,16 @@ class HypConv2DHyperboloidPP(nnx.Module):
         Output-side guard: the sinh argument ``sqrt(c)*v`` is smooth-clamped to
         ``±v_max``, bounding the output spatial norm by ``sinh(v_max)/sqrt(c)``
         (default: 10.0, matching the Shi et al. 2026 reference implementation).
+    use_gyro_bias : bool
+        If True, add a learnable intrinsic bias via Lorentz gyroaddition,
+        ``y <- y (+) exp_0([0, b])`` with ``b`` initialized to zero — the gyrogroup
+        identity, so the bias is a no-op at initialization (default: False).
+    kernel_init_std : float
+        Standard deviation of the normal kernel init (default: 0.02, the Shi et al.
+        2026 PLFC reference value; the reference conv defers to the PLFC init).
+        Use 1.0 to recover the previous HNN++-style init (Shimizu et al. 2020);
+        note that large kernels push the pre-guard scores into the ``v_max``
+        saturation regime.
     param_dtype : DTypeLike
         Storage dtype of the trainable parameters (default: jnp.float32).
         Compute precision of manifold operations is set by ``manifold.dtype``.
@@ -864,15 +886,21 @@ class HypConv2DHyperboloidPP(nnx.Module):
     Notes
     -----
     JIT Compatibility:
-        This layer is designed to work with nnx.jit. Configuration parameters (padding, input_space,
-        clamping_factor, smoothing_factor, v_max) are treated as static and baked into the compiled function.
+        This layer is designed to work with nnx.jit. Configuration parameters (padding, pad_mode,
+        input_space, clamping_factor, smoothing_factor, v_max) are treated as static and baked
+        into the compiled function.
+
+    See Also
+    --------
+    HypLinearHyperboloidPLFC : The underlying PLFC linear layer.
+    hyperbolix.manifolds.hyperboloid.Hyperboloid.log_radius_concat : The LogCat operation.
 
     References
     ----------
+    Xianglong Shi, Ziheng Chen, Yunhan Jiang, and Nicu Sebe. "Intrinsic Lorentz Neural Network."
+        ICLR 2026, arXiv:2602.23981 (Sec. 4.3: Lorentz convolution, log-radius concatenation).
     Shimizu Ryohei, Yusuke Mukuta, and Tatsuya Harada. "Hyperbolic neural networks++."
         arXiv preprint arXiv:2006.08210 (2020).
-    Xianglong Shi, Ziheng Chen, Yunhan Jiang, and Nicu Sebe. "Intrinsic Lorentz Neural Network."
-        ICLR 2026 (output-side score guard).
     """
 
     def __init__(
@@ -885,24 +913,33 @@ class HypConv2DHyperboloidPP(nnx.Module):
         rngs: nnx.Rngs,
         stride: int | tuple[int, int] = 1,
         padding: str = "SAME",
+        pad_mode: str = "origin",
         input_space: str = "manifold",
         clamping_factor: float = 1.0,
         smoothing_factor: float = 50.0,
         v_max: float = 10.0,
+        use_gyro_bias: bool = False,
+        kernel_init_std: float = 0.02,
         param_dtype: DTypeLike = jnp.float32,
     ):
         if padding not in ["SAME", "VALID"]:
             raise ValueError(f"padding must be either 'SAME' or 'VALID', got '{padding}'")
+        if pad_mode not in ("origin", "edge"):
+            raise ValueError(f"pad_mode must be 'origin' or 'edge', got '{pad_mode}'")
         if input_space not in ["tangent", "manifold"]:
             raise ValueError(f"input_space must be either 'tangent' or 'manifold', got '{input_space}'")
 
         # Static configuration
-        validate_hyperboloid_manifold(manifold_module, required_methods=("expmap_0", "compute_mlr", "hcat"))
+        required_methods = ("expmap_0", "compute_mlr", "log_radius_concat")
+        if use_gyro_bias:
+            required_methods = ("expmap_0", "compute_mlr", "log_radius_concat", "embed_spatial_0", "addition")
+        validate_hyperboloid_manifold(manifold_module, required_methods=required_methods)
         self.manifold = manifold_module
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.input_space = input_space
         self.padding = padding
+        self.pad_mode = pad_mode
         self.clamping_factor = clamping_factor
         self.smoothing_factor = smoothing_factor
         self.v_max = v_max
@@ -917,23 +954,32 @@ class HypConv2DHyperboloidPP(nnx.Module):
         else:
             self.stride = stride
 
-        # HCat output ambient dim: (in_channels - 1) * kh * kw + 1
+        # LogCat output ambient dim: (in_channels - 1) * kh * kw + 1 (same as HCat)
         kernel_h, kernel_w = self.kernel_size
         N = kernel_h * kernel_w
         d = in_channels - 1
-        hcat_out_ambient_dim = d * N + 1
+        logcat_out_ambient_dim = d * N + 1
 
-        # Trainable parameters — standard normal init (Shimizu et al. 2020)
+        # Trainable parameters — small normal init (Shi et al. 2026 PLFC reference;
+        # the reference conv defers to the PLFC reset_parameters)
         out_spatial = out_channels - 1
-        hcat_spatial = hcat_out_ambient_dim - 1
-        self.kernel = nnx.Param(jax.random.normal(rngs.params(), (out_spatial, hcat_spatial), dtype=param_dtype))
+        logcat_spatial = logcat_out_ambient_dim - 1
+        kernel_init = kernel_init_std * jax.random.normal(rngs.params(), (out_spatial, logcat_spatial), dtype=param_dtype)
+        self.kernel = nnx.Param(kernel_init)
         self.bias = nnx.Param(jnp.zeros((out_spatial, 1), dtype=param_dtype))
+
+        # Gyro-bias: spatial tangent vector at the origin, zero-initialized
+        if use_gyro_bias:
+            self.gyro_bias = nnx.Param(jnp.zeros((out_spatial,), dtype=param_dtype))
+        else:
+            self.gyro_bias = None
 
     def _extract_patches(
         self,
         x: Float[Array, "batch height width in_channels"],
+        c: float,
     ) -> Float[Array, "batch out_height out_width kernel_h kernel_w in_channels"]:
-        """Extract patches (receptive fields) from the input."""
+        """Extract patches, padding with manifold origin or edge replication for SAME mode."""
         batch, height, width, in_channels = x.shape
         kernel_h, kernel_w = self.kernel_size
         stride_h, stride_w = self.stride
@@ -948,11 +994,19 @@ class HypConv2DHyperboloidPP(nnx.Module):
             pad_left = pad_w // 2
             pad_right = pad_w - pad_left
 
-            x = jnp.pad(
-                x,
-                ((0, 0), (pad_top, pad_bottom), (pad_left, pad_right), (0, 0)),
-                mode="edge",
-            )
+            if self.pad_mode == "origin":
+                # Pad with manifold origin: (√(1/c), 0, ..., 0)
+                padded_h = height + pad_h
+                padded_w = width + pad_w
+                padded = jnp.zeros((batch, padded_h, padded_w, in_channels), dtype=x.dtype)
+                padded = padded.at[..., 0].set(jnp.sqrt(1.0 / c))
+                x = padded.at[:, pad_top : pad_top + height, pad_left : pad_left + width, :].set(x)
+            else:  # edge
+                x = jnp.pad(
+                    x,
+                    ((0, 0), (pad_top, pad_bottom), (pad_left, pad_right), (0, 0)),
+                    mode="edge",
+                )
 
         patches_flat_BHW_CKhKw = jax.lax.conv_general_dilated_patches(
             lhs=x,
@@ -995,24 +1049,24 @@ class HypConv2DHyperboloidPP(nnx.Module):
             x = x_mapped_NC.reshape(x.shape)  # (B, H, W, C)
 
         # Extract patches: (B, H', W', kh, kw, C)
-        patches_BHWkhkwC = self._extract_patches(x)
+        patches_BHWkhkwC = self._extract_patches(x, c)
         batch, out_h, out_w, kh, kw, in_c = patches_BHWkhkwC.shape
 
         # Flatten batch+spatial for parallel processing: (B*H'*W', K, C)
         patches_flat_NKC = patches_BHWkhkwC.reshape(-1, kh * kw, in_c)
 
-        # HCat: (K, C) -> (hcat_dim,) per patch
-        hcat_out_NA = jax.vmap(self.manifold.hcat, in_axes=(0, None))(patches_flat_NKC, c)  # (B*H'*W', hcat_dim)
+        # LogCat: (K, C) -> (logcat_dim,) per patch — log-radius-preserving concatenation (Shi et al. 2026, Eq. 11)
+        logcat_out_NA = jax.vmap(self.manifold.log_radius_concat, in_axes=(0, None))(patches_flat_NKC, c)
 
-        # PLFC linear: (hcat_dim,) -> (out_channels,)
+        # PLFC linear: (logcat_dim,) -> (out_channels,)
         linear_out_NC = _hyperboloid_plfc_forward(
-            hcat_out_NA,
+            logcat_out_NA,
             self.kernel[...],
             self.bias[...],
-            None,  # no gyro-bias in the conv layer
+            self.gyro_bias[...] if self.gyro_bias is not None else None,
             self.manifold,
             c,
-            "manifold",  # HCat output is already on manifold
+            "manifold",  # LogCat output is already on manifold
             self.clamping_factor,
             self.smoothing_factor,
             self.v_max,

--- a/hyperbolix/nn_layers/hyperboloid_linear.py
+++ b/hyperbolix/nn_layers/hyperboloid_linear.py
@@ -185,7 +185,7 @@ def _hyperboloid_plfc_forward(
 ) -> Float[Array, "batch out_dim"]:
     """Pure-function PLFC forward pass for the hyperboloid model.
 
-    Used by HypLinearHyperboloidPLFC and HypConv2DHyperboloidPP. Computes MLR
+    Used by HypLinearHyperboloidPLFC and HypConv2DHyperboloidILNN. Computes MLR
     scores, guards them, maps back to the hyperboloid via element-wise sinh
     diffeomorphism, and optionally applies an intrinsic gyro-bias.
     """

--- a/tests/nn_layers/test_hyperboloid_conv_ilnn.py
+++ b/tests/nn_layers/test_hyperboloid_conv_ilnn.py
@@ -1,4 +1,4 @@
-"""Tests for HypConv2DHyperboloidPP (HNN++ hyperboloid convolutional layer)."""
+"""Tests for HypConv2DHyperboloidILNN (Intrinsic Lorentz convolution: LogCat + PLFC, Shi et al. 2026)."""
 
 from functools import partial
 
@@ -8,7 +8,7 @@ import pytest
 from flax import nnx
 
 from hyperbolix.manifolds import Hyperboloid
-from hyperbolix.nn_layers import HypConv2DHyperboloidPP
+from hyperbolix.nn_layers import HypConv2DHyperboloidILNN, HypLinearHyperboloidPLFC
 
 
 def _proj_image(x, manifold, c):
@@ -26,7 +26,7 @@ def _check_on_hyperboloid(x, c, atol=1e-5):
 @pytest.mark.parametrize("padding", ["SAME", "VALID"])
 @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
 def test_output_shape(kernel_size, padding, dtype):
-    """Test HypConv2DHyperboloidPP output shape with different kernel sizes and padding."""
+    """Test HypConv2DHyperboloidILNN output shape with different kernel sizes and padding."""
     key = jax.random.PRNGKey(42)
     manifold = Hyperboloid(dtype=dtype)
     batch_size, height, width, in_channels, out_channels = 2, 8, 8, 3, 4
@@ -36,7 +36,7 @@ def test_output_shape(kernel_size, padding, dtype):
     x_manifold = _proj_image(x, manifold, c)
 
     rngs = nnx.Rngs(42)
-    layer = HypConv2DHyperboloidPP(
+    layer = HypConv2DHyperboloidILNN(
         manifold_module=manifold,
         in_channels=in_channels,
         out_channels=out_channels,
@@ -70,7 +70,7 @@ def test_output_on_manifold(dtype):
     x_manifold = _proj_image(x, manifold, c)
 
     rngs = nnx.Rngs(42)
-    layer = HypConv2DHyperboloidPP(
+    layer = HypConv2DHyperboloidILNN(
         manifold_module=manifold,
         in_channels=in_channels,
         out_channels=out_channels,
@@ -87,7 +87,7 @@ def test_output_on_manifold(dtype):
 
 @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
 def test_jitted_forward(dtype):
-    """Test HypConv2DHyperboloidPP under nnx.jit."""
+    """Test HypConv2DHyperboloidILNN under nnx.jit."""
     key = jax.random.PRNGKey(42)
     manifold = Hyperboloid(dtype=dtype)
     batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
@@ -97,7 +97,7 @@ def test_jitted_forward(dtype):
     x_manifold = _proj_image(x, manifold, c)
 
     rngs = nnx.Rngs(42)
-    layer = HypConv2DHyperboloidPP(
+    layer = HypConv2DHyperboloidILNN(
         manifold_module=manifold,
         in_channels=in_channels,
         out_channels=out_channels,
@@ -117,7 +117,7 @@ def test_jitted_forward(dtype):
 
 @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
 def test_gradient(dtype):
-    """Test HypConv2DHyperboloidPP has valid gradients."""
+    """Test HypConv2DHyperboloidILNN has valid gradients."""
     key = jax.random.PRNGKey(42)
     manifold = Hyperboloid(dtype=dtype)
     batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
@@ -127,7 +127,7 @@ def test_gradient(dtype):
     x_manifold = _proj_image(x, manifold, c)
 
     rngs = nnx.Rngs(42)
-    layer = HypConv2DHyperboloidPP(
+    layer = HypConv2DHyperboloidILNN(
         manifold_module=manifold,
         in_channels=in_channels,
         out_channels=out_channels,
@@ -148,7 +148,7 @@ def test_gradient(dtype):
 
 @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
 def test_jitted_gradient(dtype):
-    """Test HypConv2DHyperboloidPP gradients under nnx.jit."""
+    """Test HypConv2DHyperboloidILNN gradients under nnx.jit."""
     key = jax.random.PRNGKey(42)
     manifold = Hyperboloid(dtype=dtype)
     batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
@@ -158,7 +158,7 @@ def test_jitted_gradient(dtype):
     x_manifold = _proj_image(x, manifold, c)
 
     rngs = nnx.Rngs(42)
-    layer = HypConv2DHyperboloidPP(
+    layer = HypConv2DHyperboloidILNN(
         manifold_module=manifold,
         in_channels=in_channels,
         out_channels=out_channels,
@@ -180,7 +180,7 @@ def test_jitted_gradient(dtype):
 
 @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
 def test_tangent_input(dtype):
-    """Test HypConv2DHyperboloidPP with tangent space input."""
+    """Test HypConv2DHyperboloidILNN with tangent space input."""
     key = jax.random.PRNGKey(42)
     manifold = Hyperboloid(dtype=dtype)
     batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
@@ -192,7 +192,7 @@ def test_tangent_input(dtype):
     x = x.at[:, :, :, 0].set(0.0)
 
     rngs = nnx.Rngs(42)
-    layer = HypConv2DHyperboloidPP(
+    layer = HypConv2DHyperboloidILNN(
         manifold_module=manifold,
         in_channels=in_channels,
         out_channels=out_channels,
@@ -212,7 +212,7 @@ def test_tangent_input(dtype):
 @pytest.mark.parametrize("stride", [1, 2])
 @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
 def test_stride(stride, dtype):
-    """Test HypConv2DHyperboloidPP with different stride values."""
+    """Test HypConv2DHyperboloidILNN with different stride values."""
     key = jax.random.PRNGKey(42)
     manifold = Hyperboloid(dtype=dtype)
     batch_size, height, width, in_channels, out_channels = 2, 8, 8, 3, 4
@@ -223,7 +223,7 @@ def test_stride(stride, dtype):
     x_manifold = _proj_image(x, manifold, c)
 
     rngs = nnx.Rngs(42)
-    layer = HypConv2DHyperboloidPP(
+    layer = HypConv2DHyperboloidILNN(
         manifold_module=manifold,
         in_channels=in_channels,
         out_channels=out_channels,
@@ -241,7 +241,7 @@ def test_stride(stride, dtype):
 
 @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
 def test_different_curvatures(dtype):
-    """Test HypConv2DHyperboloidPP with different curvature values."""
+    """Test HypConv2DHyperboloidILNN with different curvature values."""
     key = jax.random.PRNGKey(42)
     manifold = Hyperboloid(dtype=dtype)
     batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 3
@@ -253,7 +253,7 @@ def test_different_curvatures(dtype):
         x_manifold = jax.vmap(jax.vmap(jax.vmap(proj_fn)))(x)
 
         rngs = nnx.Rngs(42)
-        layer = HypConv2DHyperboloidPP(
+        layer = HypConv2DHyperboloidILNN(
             manifold_module=manifold,
             in_channels=in_channels,
             out_channels=out_channels,
@@ -265,3 +265,173 @@ def test_different_curvatures(dtype):
 
         y_flat = y.reshape(-1, out_channels)
         assert _check_on_hyperboloid(y_flat, c=c, atol=atol), f"Failed for curvature {c}"
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_forward_is_plfc_of_log_radius_concat(dtype):
+    """Conv forward equals PLFC(LogCat(patch)) — the Shi et al. 2026 Eq. (11) pipeline."""
+    key = jax.random.PRNGKey(0)
+    manifold = Hyperboloid(dtype=dtype)
+    c = 1.0
+    kernel_size, in_channels, out_channels = 2, 3, 4
+
+    # Image size == kernel size with VALID padding -> exactly one receptive field
+    x = jax.random.normal(key, (1, kernel_size, kernel_size, in_channels), dtype=dtype) * 0.1
+    x_manifold = _proj_image(x, manifold, c)
+
+    layer = HypConv2DHyperboloidILNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        rngs=nnx.Rngs(42),
+        padding="VALID",
+    )
+    y = layer(x_manifold, c=c)  # (1, 1, 1, out_channels)
+
+    # Manual pipeline: LogCat over the receptive field, then PLFC with shared weights
+    points_KC = x_manifold.reshape(kernel_size * kernel_size, in_channels)
+    logcat_A = manifold.log_radius_concat(points_KC, c)
+
+    logcat_dim = (in_channels - 1) * kernel_size**2 + 1
+    plfc = HypLinearHyperboloidPLFC(manifold, logcat_dim, out_channels, rngs=nnx.Rngs(7))
+    plfc.kernel[...] = layer.kernel[...]
+    plfc.bias[...] = layer.bias[...]
+    expected = plfc(logcat_A[None, :], c=c)
+
+    atol = 1e-5 if dtype == jnp.float32 else 1e-10
+    assert jnp.allclose(y.reshape(1, out_channels), expected, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_origin_vs_edge_padding(dtype):
+    """SAME padding fills the border with the manifold origin by default; edge mode differs at borders only."""
+    key = jax.random.PRNGKey(42)
+    manifold = Hyperboloid(dtype=dtype)
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 4
+    c = 1.0
+    atol = 4e-3 if dtype == jnp.float32 else 1e-7
+
+    x = jax.random.normal(key, (batch_size, height, width, in_channels), dtype=dtype) * 0.1
+    x_manifold = _proj_image(x, manifold, c)
+
+    layer_origin = HypConv2DHyperboloidILNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=3,
+        rngs=nnx.Rngs(42),
+    )
+    layer_edge = HypConv2DHyperboloidILNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=3,
+        rngs=nnx.Rngs(42),
+        pad_mode="edge",
+    )
+
+    y_origin = layer_origin(x_manifold, c=c)
+    y_edge = layer_edge(x_manifold, c=c)
+
+    # Same weights (same seed): interior windows (no padding) agree, border windows differ
+    assert jnp.allclose(y_origin[:, 1:3, 1:3, :], y_edge[:, 1:3, 1:3, :], atol=1e-6)
+    assert jnp.max(jnp.abs(y_origin - y_edge)) > 1e-6
+    # Origin padding keeps the output on the manifold
+    assert _check_on_hyperboloid(y_origin.reshape(-1, out_channels), c=c, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_gyro_bias_zero_is_identity(dtype):
+    """At init the gyro-bias is zero -> gyroaddition with the origin is a no-op."""
+    key = jax.random.PRNGKey(42)
+    manifold = Hyperboloid(dtype=dtype)
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 4
+    c = 1.0
+    atol = 1e-5 if dtype == jnp.float32 else 1e-12
+
+    x = jax.random.normal(key, (batch_size, height, width, in_channels), dtype=dtype) * 0.1
+    x_manifold = _proj_image(x, manifold, c)
+
+    layer_plain = HypConv2DHyperboloidILNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=nnx.Rngs(42),
+    )
+    layer_gyro = HypConv2DHyperboloidILNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=nnx.Rngs(42),
+        use_gyro_bias=True,
+    )
+
+    y_plain = layer_plain(x_manifold, c=c)
+    y_gyro = layer_gyro(x_manifold, c=c)
+
+    assert jnp.allclose(y_plain, y_gyro, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_gyro_bias_on_manifold_and_trainable(dtype):
+    """Nonzero gyro-bias keeps the output on the manifold and receives gradients."""
+    key = jax.random.PRNGKey(42)
+    manifold = Hyperboloid(dtype=dtype)
+    batch_size, height, width, in_channels, out_channels = 2, 4, 4, 3, 4
+    c = 1.0
+    atol = 4e-3 if dtype == jnp.float32 else 1e-7
+
+    x = jax.random.normal(key, (batch_size, height, width, in_channels), dtype=dtype) * 0.1
+    x_manifold = _proj_image(x, manifold, c)
+
+    layer = HypConv2DHyperboloidILNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=2,
+        rngs=nnx.Rngs(42),
+        use_gyro_bias=True,
+    )
+    bias_key = jax.random.PRNGKey(7)
+    layer.gyro_bias[...] = jax.random.normal(bias_key, (out_channels - 1,), dtype=layer.gyro_bias[...].dtype) * 0.3
+
+    y = layer(x_manifold, c=c)
+
+    assert jnp.isfinite(y).all()
+    assert _check_on_hyperboloid(y.reshape(-1, out_channels), c=c, atol=atol)
+
+    def loss_fn(model):
+        return jnp.sum(model(x_manifold, c=c) ** 2)
+
+    loss, grads = nnx.value_and_grad(loss_fn)(layer)
+    assert jnp.isfinite(loss)
+    assert jnp.isfinite(grads.gyro_bias[...]).all()
+    assert jnp.any(grads.gyro_bias[...] != 0.0)
+
+
+def test_kernel_init_std():
+    """Default kernel init follows the PLFC reference (std=0.02); kernel_init_std=1.0 recovers HNN++."""
+    manifold = Hyperboloid(dtype=jnp.float32)
+    in_channels, out_channels, kernel_size = 9, 17, 3  # (16, 72) kernel -> 1152 samples
+
+    layer_default = HypConv2DHyperboloidILNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        rngs=nnx.Rngs(42),
+    )
+    layer_hnnpp = HypConv2DHyperboloidILNN(
+        manifold_module=manifold,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        rngs=nnx.Rngs(42),
+        kernel_init_std=1.0,
+    )
+
+    assert abs(float(jnp.std(layer_default.kernel[...])) - 0.02) < 0.005
+    assert 0.8 < float(jnp.std(layer_hnnpp.kernel[...])) < 1.2


### PR DESCRIPTION
## Summary

- Renames `HypConv2DHyperboloidPP` → `HypConv2DHyperboloidILNN` to match Shi et al. 2026 (ILNN) paper terminology (the old name referred to "HNN++" which is the precursor method).
- Upgrades the layer implementation: **LogCat** (log-radius-preserving concatenation) replaces the old **HCat** (Lorentz direct concatenation), **origin padding** replaces zero-padding for SAME convolutions, learnable **gyro-bias** support added, and **`kernel_init_std`** exposed for controlling initialization scale.
- Updates `__init__.py` exports, docs, and test file to reflect the rename.

## Test plan

- [x] CI passes for `tests/nn_layers/test_hyperboloid_conv_ilnn.py`
- [x] Existing hyperboloid layer tests unaffected
- [x] Docs build cleanly (`mkdocs build --strict`)