### PR TITLE
docs: Vendor only the MathJax component the docs load (fixes Pages deploy timeout)

### DIFF
--- a/scripts/vendor_mathjax.py
+++ b/scripts/vendor_mathjax.py
@@ -35,6 +35,26 @@ EXPECTED_SHA512_B64 = "Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1
 DEST = Path("docs/javascripts/mathjax")
 PREFIX = "package/es5/"  # the self-contained engine + fonts live under es5/ in the npm tarball
 
+# The docs load exactly one combined MathJax component — see mkdocs.yml
+# `extra_javascript: javascripts/mathjax/tex-mml-chtml.js`. That component is
+# self-contained JS (bundles loader + TeX/MathML input + CHTML output) and only
+# lazy-loads CHTML web fonts from output/chtml/fonts/woff-v2/ at runtime.
+#
+# Vendoring the whole es5/ tree (~24 MB: SVG output, the speech-rule engine,
+# every other component) ships ~22 MB per version that the page never requests.
+# Because `mike` stores each docs version as a full independent copy on the
+# gh-pages branch, that waste is multiplied by every release and pushed the
+# published site (13 versions, 219 MB) past GitHub Pages' deploy limit, timing
+# out `actions/deploy-pages` at its 10-minute ceiling. Vendor only what the page
+# actually references (~1.5 MB/version).
+KEEP_FILE = "tex-mml-chtml.js"  # the single component mkdocs loads
+KEEP_DIR = "output/chtml/fonts/woff-v2/"  # CHTML web fonts it fetches on demand
+
+
+def _wanted(name: str) -> bool:
+    """True for the one component bundle and its CHTML web fonts (paths are es5-relative)."""
+    return name == KEEP_FILE or name.startswith(KEEP_DIR)
+
 
 def main() -> int:
     url = f"https://registry.npmjs.org/mathjax/-/mathjax-{MATHJAX_VERSION}.tgz"
@@ -59,8 +79,11 @@ def main() -> int:
             if not member.name.startswith(PREFIX):
                 continue
             member.name = member.name[len(PREFIX) :]  # strip "package/es5/"
-            if member.name:
+            if member.name and _wanted(member.name):
                 members.append(member)
+        if not any(m.name == KEEP_FILE for m in members):
+            print(f"EXPECTED FILE MISSING — {KEEP_FILE!r} not found in tarball es5/", file=sys.stderr)
+            return 1
         # filter="data" (Python 3.12+) rejects path traversal / unsafe members.
         tar.extractall(DEST, members=members, filter="data")
 


### PR DESCRIPTION
## Problem

GitHub Pages deployment has been failing since the **v0.10.2** release (2026-07-02). The failing job is GitHub's auto-generated **`pages-build-deployment`** (the legacy branch-deploy triggered when `mike` pushes to `gh-pages`), not our `Documentation` workflow (which succeeds in ~40s). Its `deploy` step (`actions/deploy-pages@v5`) hung polling `deployment_queued`/`in_progress` and died at the **10-minute ceiling**; the Pages API recorded `status: errored, error: "Page build failed."`

## Root cause

`scripts/vendor_mathjax.py` extracted the **entire** MathJax `es5/` tree (~24 MB — SVG output, the 3.8 MB speech-rule engine, `a11y/`, every component bundle) into every version. But `mkdocs.yml` loads exactly one file, `tex-mml-chtml.js` (+ its CHTML `woff-v2` fonts, ~1.5 MB). Because `mike` stores each release as a full independent copy on `gh-pages`, the ~22 MB of unused files per version multiplied to **138 MB (63%) of a 219 MB branch** — crossing the point where GitHub's Pages backend can't finalize the deploy within 10 minutes. The v0.10.2 release added the last full snapshot that tipped it over (a 41s success on Jul 1 → 10-min timeouts on Jul 2).

## Fix

Vendor only `tex-mml-chtml.js` + `output/chtml/fonts/woff-v2/`:
- Vendored output **24 MB → 1.6 MB**; a built site **~30 MB → 9.6 MB**.
- Tarball SHA-512 integrity check **unchanged**; external-host audit still passes (**no runtime CDN** — self-hosting/CSP guarantee preserved).
- `mkdocs build --strict` passes; all versions reference this exact component, so math still renders.

## Deployment already restored

The `gh-pages` branch was pruned to match in a separate commit (`0ce7b26`, **224 MB → 94 MB**), which redeployed successfully in **~28s** (`pages_build=built`, deploy job green). Live site, `tex-mml-chtml.js`, and old versions all serve `200`; deleted files `404` as intended. This PR prevents the bloat from recurring on the next `latest`/release deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)