### PR TITLE
fix(optim): has_manifold_params never detected ManifoldParam

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`hyperbolix.optim.has_manifold_params` always returned `False`.** `nnx.Variable` is itself a registered pytree node whose single child is the raw array, so the unguarded `jax.tree_util.tree_leaves` call unwrapped every `ManifoldParam` into an `ArrayImpl` before the `isinstance` check ran — the function reported "no manifold parameters" for a bare `ManifoldParam`, a dict of parameters, `nnx.state(model, nnx.Param)` (its own documented usage) and a model alike. The traversal now stops at `nnx.Variable` leaves. The Riemannian optimizers were **not** affected: `_riemannian_base` already flattened with that guard everywhere it inspects Variable types, so only callers using `has_manifold_params` as a guard saw the false negative
+
 ## [1.0.0] - 2026-07-24
 
 First stable release. The public API is considered complete and stable, reaching functional

--- a/hyperbolix/optim/_riemannian_base.py
+++ b/hyperbolix/optim/_riemannian_base.py
@@ -33,7 +33,7 @@ import optax
 from flax import nnx
 from jax import tree_util
 
-from .manifold_metadata import ManifoldParam
+from .manifold_metadata import ManifoldParam, _is_variable_leaf
 
 # Dimension key:
 #   D: manifold point dim (last axis)    N: number of points in a leaf
@@ -44,10 +44,6 @@ def _resolve_lr(learning_rate: float | optax.Schedule, count: jnp.ndarray) -> jn
     if callable(learning_rate):
         return jnp.asarray(learning_rate(count))
     return jnp.asarray(cast(float, learning_rate))
-
-
-def _is_variable_leaf(x: Any) -> bool:
-    return isinstance(x, nnx.Variable)
 
 
 def _unwrap(x: Any) -> Any:

--- a/hyperbolix/optim/manifold_metadata.py
+++ b/hyperbolix/optim/manifold_metadata.py
@@ -43,6 +43,18 @@ from flax import nnx
 from hyperbolix.manifolds import Manifold
 
 
+def _is_variable_leaf(x: Any) -> bool:
+    """Treat ``nnx.Variable`` instances as pytree leaves.
+
+    ``nnx.Variable`` is itself a registered pytree node whose single child is
+    the raw array, so an unguarded ``tree_leaves`` unwraps a ``ManifoldParam``
+    into an ``ArrayImpl`` and any ``isinstance`` check against the Variable
+    type silently fails.  Every traversal that inspects Variable *types* (as
+    opposed to values) must stop the descent here.
+    """
+    return isinstance(x, nnx.Variable)
+
+
 class ManifoldParam(nnx.Param):
     """``nnx.Param`` subclass for parameters living on a Riemannian manifold.
 
@@ -167,6 +179,7 @@ def has_manifold_params(params_pytree: Any) -> bool:
     ----------
     params_pytree : Any
         A pytree of parameters (typically from ``nnx.state(model, nnx.Param)``).
+        A bare ``ManifoldParam`` or an ``nnx.Module`` also works.
 
     Returns
     -------
@@ -185,5 +198,8 @@ def has_manifold_params(params_pytree: Any) -> bool:
     """
     from jax import tree_util
 
-    leaves = tree_util.tree_leaves(params_pytree)
+    # is_leaf is required, not an optimization: without it the traversal
+    # descends through each Variable to its raw array and the isinstance
+    # check below can never fire.  See _is_variable_leaf.
+    leaves = tree_util.tree_flatten(params_pytree, is_leaf=_is_variable_leaf)[0]
     return any(isinstance(leaf, ManifoldParam) for leaf in leaves)

--- a/tests/nn_layers/test_hyperboloid_activations.py
+++ b/tests/nn_layers/test_hyperboloid_activations.py
@@ -6,6 +6,8 @@ import pytest
 
 from hyperbolix.manifolds.hyperboloid import Hyperboloid
 from hyperbolix.nn_layers.hyperboloid_activations import (
+    hrc_gelu,
+    hyp_gelu,
     hyp_leaky_relu,
     hyp_relu,
     hyp_swish,
@@ -119,6 +121,42 @@ def test_hyp_swish_manifold_constraint(dtype):
 
     is_valid = jax.vmap(hyperboloid.is_in_manifold, in_axes=(0, None))(y, 1.0)
     assert is_valid.all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_hyp_gelu_manifold_constraint(dtype):
+    """Test that hyp_gelu output lies on manifold."""
+    hyperboloid = Hyperboloid(dtype=dtype)
+    key = jax.random.PRNGKey(46)
+    batch_size, dim = 8, 4
+
+    v = jax.random.normal(key, (batch_size, dim), dtype=dtype) * 0.1
+    x = jax.vmap(hyperboloid.expmap_0, in_axes=(0, None))(v, 1.0)
+
+    y = hyp_gelu(x, c=1.0)
+
+    is_valid = jax.vmap(hyperboloid.is_in_manifold, in_axes=(0, None))(y, 1.0)
+    assert is_valid.all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+@pytest.mark.parametrize("c", [0.5, 1.0, 2.0])
+def test_hyp_gelu_delegates_to_hrc_gelu(dtype, c):
+    """hyp_gelu is the curvature-preserving wrapper hrc_gelu(x, c_in=c, c_out=c).
+
+    The wrapper body is one line of argument wiring with no caller inside the
+    library, so nothing else pins the curvature reaching both c_in and c_out.
+    Parametrized over c because c_in == c_out makes any single-curvature check
+    blind to the two arguments being swapped or one being dropped.
+    """
+    hyperboloid = Hyperboloid(dtype=dtype)
+    key = jax.random.PRNGKey(46)
+    batch_size, dim = 8, 4
+
+    v = jax.random.normal(key, (batch_size, dim), dtype=dtype) * 0.1
+    x = jax.vmap(hyperboloid.expmap_0, in_axes=(0, None))(v, c)
+
+    assert jnp.array_equal(hyp_gelu(x, c=c), hrc_gelu(x, c_in=c, c_out=c))
 
 
 # ============================================================================
@@ -359,6 +397,26 @@ def test_hyp_swish_gradients(dtype):
     assert grad.shape == x.shape
 
 
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_hyp_gelu_gradients(dtype):
+    """Test that hyp_gelu has finite gradients."""
+    hyperboloid = Hyperboloid(dtype=dtype)
+    key = jax.random.PRNGKey(46)
+    dim = 4
+
+    v = jax.random.normal(key, (dim,), dtype=dtype) * 0.1
+    x = hyperboloid.expmap_0(v, c=1.0)
+
+    def loss_fn(x):
+        y = hyp_gelu(x, c=1.0)
+        return jnp.sum(y**2)
+
+    grad = jax.grad(loss_fn)(x)
+
+    assert jnp.isfinite(grad).all()
+    assert grad.shape == x.shape
+
+
 # ============================================================================
 # JIT Compatibility Tests
 # ============================================================================
@@ -440,6 +498,27 @@ def test_hyp_swish_jit(dtype):
     @jax.jit
     def apply_activation(x):
         return hyp_swish(x, c=1.0)
+
+    y = apply_activation(x)
+
+    assert y.shape == x.shape
+    is_valid = jax.vmap(hyperboloid.is_in_manifold, in_axes=(0, None))(y, 1.0)
+    assert is_valid.all()
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_hyp_gelu_jit(dtype):
+    """Test that hyp_gelu works with JIT compilation."""
+    hyperboloid = Hyperboloid(dtype=dtype)
+    key = jax.random.PRNGKey(46)
+    batch_size, dim = 8, 4
+
+    v = jax.random.normal(key, (batch_size, dim), dtype=dtype) * 0.1
+    x = jax.vmap(hyperboloid.expmap_0, in_axes=(0, None))(v, 1.0)
+
+    @jax.jit
+    def apply_activation(x):
+        return hyp_gelu(x, c=1.0)
 
     y = apply_activation(x)
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -19,7 +19,9 @@ from flax import nnx
 from hyperbolix.manifolds.poincare import Poincare
 from hyperbolix.nn_layers import HypLinearPoincare
 from hyperbolix.optim import (
+    ManifoldParam,
     get_manifold_info,
+    has_manifold_params,
     mark_manifold_param,
     riemannian_adam,
     riemannian_sgd,
@@ -52,6 +54,47 @@ def test_unmarked_parameter():
     param = nnx.Param(jnp.array([0.1, 0.2]))
     manifold_info = get_manifold_info(param)
     assert manifold_info is None
+
+
+def test_has_manifold_params_bare_param():
+    """A bare ManifoldParam is detected.
+
+    Regression: ``nnx.Variable`` is a registered pytree node whose child is the
+    raw array, so an unguarded ``tree_leaves`` unwraps the ManifoldParam into an
+    ArrayImpl and the detection returns False for *every* input.
+    """
+    param = ManifoldParam(jnp.array([0.1, 0.2]), manifold=poincare, curvature=1.0)
+    assert has_manifold_params(param)
+
+
+def test_has_manifold_params_in_containers():
+    """Detection works through plain dict/list containers."""
+    param = ManifoldParam(jnp.array([0.1, 0.2]), manifold=poincare, curvature=1.0)
+    assert has_manifold_params({"bias": param})
+    assert has_manifold_params([nnx.Param(jnp.zeros(3)), param])
+
+
+def test_has_manifold_params_on_model_state():
+    """The documented usage — nnx.state(model, nnx.Param) — and the model itself."""
+    layer = HypLinearPoincare(
+        poincare,
+        in_dim=5,
+        out_dim=3,
+        rngs=nnx.Rngs(0),
+    )
+
+    assert has_manifold_params(nnx.state(layer, nnx.Param))
+    assert has_manifold_params(layer)
+
+
+def test_has_manifold_params_negative_cases():
+    """No false positives on Euclidean params, raw arrays, or empty pytrees."""
+    euclidean_layer = nnx.Linear(5, 3, rngs=nnx.Rngs(0))
+
+    assert not has_manifold_params(nnx.state(euclidean_layer, nnx.Param))
+    assert not has_manifold_params(nnx.Param(jnp.zeros(3)))
+    assert not has_manifold_params({"kernel": jnp.zeros((5, 3))})
+    assert not has_manifold_params({})
 
 
 def test_callable_curvature():


### PR DESCRIPTION
## The bug

`hyperbolix.optim.has_manifold_params` returned `False` for **every** input — a bare `ManifoldParam`, a dict of parameters, `nnx.state(model, nnx.Param)` (its own documented usage), and a model alike. Reproduced against flax 0.12.5 / jax 0.9.1.

`nnx.Variable` is itself a registered pytree node whose single child is the raw array, so the unguarded `tree_leaves()` call unwrapped every `ManifoldParam` into an `ArrayImpl` before the `isinstance` check ran:

```
default leaves    : ['ArrayImpl', 'ArrayImpl']
is_leaf=Variable  : ['ManifoldParam', 'Param']
```

**The Riemannian optimizers were not affected.** `_riemannian_base` already flattens with `is_leaf=_is_variable_leaf` everywhere it inspects Variable types; `has_manifold_params` was the one traversal in the module missing that guard. Only callers using it as a guard saw the false negative.

## The fix

- Traversal now stops at `nnx.Variable` leaves.
- `_is_variable_leaf` moves from `_riemannian_base.py` into `manifold_metadata.py` as the single shared definition (`_riemannian_base` imports it from there; the reverse would be circular), with a docstring on why the guard is load-bearing.
- Four regression tests: bare param, containers, model state and model, plus negative cases for Euclidean params, raw arrays and empty pytrees. Three of the four fail against the old implementation; the negative-cases test passes either way by design, to catch a future over-broad fix.
- Changelog entry under `[Unreleased]`.

## Also included

The root cause was a public, documented, untested export, so I checked the rest of the surface: of 116 names in `__all__`, three were never referenced in `tests/`. Two turned out to be covered indirectly (`sinh_lift_to_hyperboloid` — 81 runtime calls via the PLFC and Busemann layers; `transform_horopca` — via `jax.jit(transform_horopca)` behind `HoroPCA.transform`). The third, `hyp_gelu`, was a real gap: zero callers in `hyperbolix/`, zero test references, while its four siblings (`hyp_relu`, `hyp_leaky_relu`, `hyp_tanh`, `hyp_swish`) all have coverage.

Its wiring was already correct, so the final commit only pins behavior — no library change. The delegation test is parametrized over `c ∈ {0.5, 1.0, 2.0}` because `c_in == c_out` makes any single-curvature check blind to a swapped or dropped argument: mutating `c_out` to a hardcoded `1.0` leaves every other test in the file green.

## Verification

`tests/test_optimizers.py` 27/27, `tests/nn_layers/test_hyperboloid_activations.py` 98/98, `ruff check` clean, `pyright` 0 errors, pre-commit hooks passed on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)