### PR TITLE
Docs audit + release v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Hyperbolic Deep Learning in JAX
 
-[![Tests](https://img.shields.io/badge/tests-3500%2B%20passing-brightgreen)]()
+[![Tests](https://img.shields.io/badge/tests-3550%2B%20passing-brightgreen)]()
 [![Python](https://img.shields.io/badge/python-3.12%2B-blue)]()
 [![JAX](https://img.shields.io/badge/JAX-compatible-orange)]()
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
@@ -13,11 +13,11 @@ Pure JAX implementation of hyperbolic deep learning with manifold operations, ne
 
 - 🌐 **6 Manifolds**: Euclidean, Poincaré Ball, Hyperboloid, Proper Velocity, κ-Stereographic (signed curvature — hyperbolic, flat, and spherical in one manifold), and Product Manifold (mixed-curvature composition)
 - 🎛️ **Learnable Curvature**: `LearnableCurvature` module bundles parameter + reparameterization (softplus, log/exp, or signed identity) + optional clamp. Works with any `nnx.Optimizer` — no Riemannian optimizer needed
-- 🧠 **20+ Neural Network Layers**: Linear, convolutional, regression, attention, positional encoding, PV
+- 🧠 **40+ Neural Network Layers**: Linear, convolutional, regression, attention, normalization, positional encoding, PV
 - ⚡ **5 Hyperbolic Activations**: ReLU, Leaky ReLU, Tanh, Swish, GELU
 - 📈 **Riemannian Optimizers**: RAdam and RSGD with automatic manifold detection
 - 🚀 **Pure JAX/Flax NNX**: vmap-native API, JIT-compatible (10-100x speedup)
-- ✅ **3,500+ tests passing** (850+ test functions, parametrized across seeds, dtypes, manifolds) with comprehensive benchmark suite
+- ✅ **3,550+ tests passing** (735 test functions, parametrized across dtypes, dimensions, manifolds) checked against independently transcribed NumPy/SciPy oracles
 
 ## Quick Start
 

--- a/docs/api-reference/decomposition.md
+++ b/docs/api-reference/decomposition.md
@@ -35,6 +35,10 @@ import jax.numpy as jnp
 from hyperbolix.manifolds import Hyperboloid
 from hyperbolix.decomposition import HoroPCA
 
+# HoroPCA optimizes Busemann coordinates near the ideal boundary — request x64
+# before the first array is created, or every float64 below truncates to float32.
+jax.config.update("jax_enable_x64", True)
+
 manifold = Hyperboloid(dtype=jnp.float64)
 key = jax.random.PRNGKey(0)
 

--- a/docs/api-reference/distributions.md
+++ b/docs/api-reference/distributions.md
@@ -140,7 +140,7 @@ mean_ambient = jnp.concatenate([
 # Sample
 key = jax.random.PRNGKey(123)
 samples = wrapped_normal_hyperboloid.sample(
-    key, mean_ambient, std=0.15, c=1.0, sample_shape=(50,), manifold_module=hyperboloid
+    key, mean_ambient, sigma=0.15, c=1.0, sample_shape=(50,), manifold_module=hyperboloid
 )
 
 # Compute log probabilities

--- a/docs/api-reference/utils.md
+++ b/docs/api-reference/utils.md
@@ -29,7 +29,7 @@ y = acosh(x)  # Handles edge cases near 1.0
 
 # Smooth clamping for stability
 z = jnp.array([0.99, 1.0, 1.01])
-z_clamped = smooth_clamp(z, min_val=0.0, max_val=1.0)
+z_clamped = smooth_clamp(z, min_value=0.0, max_value=1.0)
 ```
 
 ## Learnable Curvature
@@ -141,8 +141,8 @@ delta, diameter, rel_delta = get_delta(
     points_proj,
     manifold_module=poincare,
     c=1.0,
-    sample_size=500,  # Number of 4-point samples
-    seed=42
+    sample_size=500,  # Points subsampled before the pairwise distance matrix
+    key=jax.random.PRNGKey(42),  # Only used when len(points) > sample_size
 )
 
 print(f"Delta: {delta:.4f}")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-01
+
+A correctness release. A full audit of the test suite replaced shape-only checks and
+self-comparisons with independently transcribed NumPy/SciPy oracles, and every library
+defect it exposed is fixed below. No new capability beyond `hyp_flatten2d`; several
+corrections change behavior or call signatures, each marked **Breaking** and each with the
+migration in its entry.
+
 ### Added
 - **`hyp_flatten2d`** (`hyperbolix.nn_layers`) — radius-preserving flatten of an NHWC hyperboloid feature map into one manifold point per image via `Hyperboloid.log_radius_concat`: `(B, H, W, A) → (B, H·W·(A−1)+1)`. The naive alternative (reshape + `hcat`) inflates the expected spatial radius by `≈ √(H·W)` (a 4×4 map: 4×); LogCat's digamma rescale hands the classifier head the per-pixel radius unchanged. This is the flatten step for `HypConv2DHyperboloidILNN` stacks feeding `HypRegressionHyperboloid`/`FGGLorentzMLR`
 - **`Poincare.proj_batch`** — batched sibling of `Hyperboloid.proj_batch` (arbitrary leading axes, bit-identical to `vmap(proj)`); HoroPCA and CO-SNE now use it instead of hand-rolled vmaps
@@ -43,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rewrote the layer initialization-scale table to match actual defaults (split `HypLinear*PP` from the regression heads; added `HypLinearHyperboloidPLFC` and `HypConv2DHyperboloidILNN` rows); fixed ambient-vs-spatial channel-convention contradictions (documented the `HTCLinear.out_features`-is-spatial exception; HCat growth is internal — output width is always `out_channels`); corrected "manifold-valued weights" to "manifold-valued bias" for the legacy Ganea layers and repositioned `mark_manifold_param` as guidance for hand-rolled parameters (built-in layers self-tag)
 - Real Hypformer citation (Yang et al. 2025) in 7 docstrings; `LorentzConv2D` attribution unified on LResNet; superseded-by notes on `LorentzConv2D`, `HypLinearPoincare`, `HypRegressionPoincare`; `param_dtype` compute-precision wording corrected across the manifold-free layers; GyroBN shift/weight comment labels un-swapped; `DEVELOPER_GUIDE.md` pointers fixed
 - Deleted the three placeholder "coming soon" tutorial notebooks and the dead commented-out `mkdocs-jupyter` configuration; updated stale `docs/index.md` counts
+- Every `python` fence in `docs/`, `README.md`, and `DEVELOPER_GUIDE.md` is now executed as a check. Four more raised: `smooth_clamp(min_val=, max_val=)` (the arguments are `min_value`/`max_value`), `get_delta(seed=42)` (it takes a `key`), `wrapped_normal_hyperboloid.sample(std=)` (it takes `sigma`), and the `is_in_manifold` example, whose "hyperboloid point" was never on the sheet (`-1.5² + 0.2² + 0.3² + 0.1² = -2.11`, not `-1`) — it now builds the ambient point with `spatial_to_hyperboloid`. The HoroPCA example requested `float64` without enabling x64, so it silently truncated to float32 with three `UserWarning`s
+- New sections for two breaking changes that previously appeared only in this changelog: the `atol` convention and `default_atol` ([Numerical Stability](user-guide/numerical-stability.md#the-atol-convention)) and learning-rate-schedule timing ([Optimizers](user-guide/optimizers.md#learning-rate-schedules))
+- Corrected the layer and test counts in `README.md` and `docs/index.md`: 20+ → 40+ layers, and "3,500+ tests / 850+ test functions" → 3,551 items across 735 test functions
 
 ## [1.0.0] - 2026-07-24
 
@@ -261,7 +272,8 @@ versioning.
 ### References
 - Based on research by Ganea et al. (2018), Bécigneul & Ganea (2019), Bdeir et al. (2023)
 
-[Unreleased]: https://github.com/timoklein/hyperbolix/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/timoklein/hyperbolix/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/timoklein/hyperbolix/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/timoklein/hyperbolix/compare/v0.11.1...v1.0.0
 [0.11.1]: https://github.com/timoklein/hyperbolix/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/timoklein/hyperbolix/compare/v0.10.2...v0.11.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Hyperbolix is a pure JAX implementation of hyperbolic deep learning, providing m
 
 - **6 Manifolds**: Euclidean, Poincaré Ball, Hyperboloid, Proper Velocity, κ-Stereographic (signed curvature — hyperbolic, flat, and spherical in one manifold), and Product Manifold (mixed-curvature composition) — all with complete geometric operations
 - **Learnable Curvature**: `LearnableCurvature` module bundles parameter + reparameterization (softplus, log/exp, or signed identity) + optional clamp; works with any `nnx.Optimizer`
-- **Neural Network Layers**: 20+ hyperbolic layers including linear, convolutional, regression, attention, and PV layers
+- **Neural Network Layers**: 40+ hyperbolic layers including linear, convolutional, regression, attention, normalization, and PV layers
 - **Activation Functions**: 5 hyperbolic activations (ReLU, Leaky ReLU, Tanh, Swish, GELU)
 - **Riemannian Optimizers**: RAdam and RSGD with automatic manifold parameter detection
 - **Wrapped Normal Distributions**: For probabilistic modeling on hyperbolic manifolds
@@ -16,7 +16,7 @@ Hyperbolix is a pure JAX implementation of hyperbolic deep learning, providing m
 - **Pure JAX/Flax NNX**: No PyTorch dependency, fully compatible with JAX ecosystem
 - **vmap-native API**: Efficient batching through JAX's functional paradigm
 - **JIT-compatible**: All operations support JIT compilation for performance
-- **Comprehensive Test Suite**: 3,400+ tests (parametrized across seeds, dtypes, manifolds) with 100% pass rate
+- **Comprehensive Test Suite**: 3,550+ tests (parametrized across dtypes, dimensions, manifolds) checked against independently transcribed NumPy/SciPy oracles
 
 ## Quick Example
 
@@ -86,7 +86,7 @@ output = model(input_data, c=1.0)
 
 ## Project Status
 
-**Stable — current release: v1.0.0.** The public API is complete and stable, reaching functional parity with the broader hyperbolic deep learning ecosystem; changes follow semantic versioning and new layers and manifolds continue to be added. See the [Changelog](changelog.md) for the full release history.
+**Stable — current release: v1.1.0.** The public API is complete and stable, reaching functional parity with the broader hyperbolic deep learning ecosystem; changes follow semantic versioning and new layers and manifolds continue to be added. See the [Changelog](changelog.md) for the full release history.
 
 | Capability | Status | Shipped in |
 |---|---|---|

--- a/docs/user-guide/numerical-stability.md
+++ b/docs/user-guide/numerical-stability.md
@@ -677,19 +677,39 @@ Each manifold provides `is_in_manifold` for validation:
 
 ```python
 from hyperbolix.manifolds import Poincare, Hyperboloid
+from hyperbolix.nn_layers import spatial_to_hyperboloid
 import jax.numpy as jnp
 
 poincare = Poincare()
 hyperboloid = Hyperboloid()
 
-# Poincaré ball: ||x||² < 1/c
+# Poincaré ball: c·||x||² < 1
 x = jnp.array([0.5, 0.3])
-assert poincare.is_in_manifold(x, c=1.0, atol=1e-5)
+assert poincare.is_in_manifold(x, c=1.0)
 
-# Hyperboloid: -x₀² + Σxᵢ² = -1/c  (with x₀ > 0)
-x_ambient = jnp.array([1.5, 0.2, 0.3, 0.1])  # (dim+1,)
-assert hyperboloid.is_in_manifold(x_ambient, c=1.0, atol=1e-5)
+# Hyperboloid: -x₀² + Σxᵢ² = -1/c  (with x₀ > 0). Building the ambient point
+# from its spatial part is the only way to land on the sheet exactly:
+# x₀ = sqrt(||x_spatial||² + 1/c).
+x_ambient = spatial_to_hyperboloid(jnp.array([0.2, 0.3, 0.1]), 1.0, 1.0)  # (dim+1,)
+assert hyperboloid.is_in_manifold(x_ambient, c=1.0)
 ```
+
+### The `atol` Convention
+
+`is_in_manifold` and `is_in_tangent_space` take `atol: float | None = None`.
+Left as `None`, every manifold resolves it through
+`hyperbolix.manifolds._base.default_atol(dtype) = sqrt(finfo(dtype).eps)` —
+`3.45e-4` in float32, `1.49e-8` in float64. An explicit value is used as given:
+it is never floored, clamped, or ignored (through v1.0.0 the hyperboloid floored
+it at `1e-4`, so no caller could tighten it, and the Poincaré ball dropped it
+entirely). Ball membership tests
+the dimensionless residual `c||x||² - 1`, so one tolerance means the same thing
+at every curvature.
+
+The float64 default is strict enough to matter at large radii: a genuinely
+on-sheet hyperboloid point past hyperbolic distance ~11 accumulates more than
+`1.49e-8` of Lorentz residual just from storing `x₀`, so validate far-out points
+with an explicit `atol` rather than assuming the default is a bug.
 
 ### Batch Validation
 

--- a/docs/user-guide/optimizers.md
+++ b/docs/user-guide/optimizers.md
@@ -124,6 +124,34 @@ You don't need separate optimizers for the Euclidean and manifold parts.
     the need for Riemannian optimization entirely. The numerics are typically
     cleaner and the optimizer setup is simpler.
 
+## Learning-Rate Schedules
+
+Both optimizers accept an `optax.Schedule` (any `count -> lr` callable) in
+place of a float, and re-read it on every `update()`:
+
+```python
+import optax
+from hyperbolix.optim import riemannian_adam
+
+schedule = optax.warmup_cosine_decay_schedule(
+    init_value=0.0, peak_value=1e-3, warmup_steps=100, decay_steps=10_000
+)
+optimizer = nnx.Optimizer(model, riemannian_adam(schedule), wrt=nnx.Param)
+```
+
+The schedule is resolved at the **pre-increment** step count, matching optax's
+`scale_by_schedule`: the k-th `update()` reads `schedule(k - 1)`, so the very
+first update uses `schedule(0)`. Adam-style bias correction deliberately keeps
+the post-increment count (`1 - beta**k`), which is also what optax's
+`scale_by_adam` does — the two are different counters by design. Constant
+learning rates are unaffected by this distinction.
+
+!!! warning "Behavior change after v1.0.0"
+    Through v1.0.0 the schedule was resolved at the post-increment count, so a
+    warmup ran one step ahead of the equivalent optax setup and `schedule(0)`
+    was never used. Runs that pinned a schedule against an optax baseline will
+    shift by one step.
+
 ## Common Pitfalls
 
 1. **Using `riemannian_adam` for HTC / FGG / PP / PV layers.** Adds compute

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hyperbolix"
-version = "1.0.0"
+version = "1.1.0"
 description = "Hyperbolic Deep Learning in JAX"
 authors = [
     { name="Timo Klein", email="timo.klein@univie.ac.at" },

--- a/uv.lock
+++ b/uv.lock
@@ -978,7 +978,7 @@ wheels = [
 
 [[package]]
 name = "hyperbolix"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "chex" },


### PR DESCRIPTION
Follow-up to #62: verifies the documentation against the merged library, fixes what it found, and promotes the Unreleased changelog to v1.1.0.

## Doc audit method

Every ` ```python ` fence in `docs/`, `README.md`, and `DEVELOPER_GUIDE.md` was executed against the merged tree — first each block standalone, then cumulatively per page (a reader following a page top to bottom). The cumulative pass is what surfaced `sample(std=)`, whose standalone run had died earlier on an unimported name.

## Broken examples fixed (5)

| Location | Defect |
|---|---|
| `api-reference/utils.md` | `smooth_clamp(min_val=, max_val=)` — the arguments are `min_value`/`max_value` |
| `api-reference/utils.md` | `get_delta(seed=42)` — it takes a `key` |
| `api-reference/distributions.md` | `wrapped_normal_hyperboloid.sample(std=)` — it takes `sigma` |
| `user-guide/numerical-stability.md` | the "hyperboloid point" was never on the sheet (`-1.5² + 0.2² + 0.3² + 0.1² = -2.11`, not `-1`), so the assert failed at any `atol`; now built with `spatial_to_hyperboloid` |
| `api-reference/decomposition.md` | HoroPCA example requested `float64` without enabling x64 — silent truncation to float32 plus three `UserWarning`s |

## Documentation gaps closed

Two breaking changes from #62 lived only in the changelog and now have guide sections:

- **The `atol` convention** — `default_atol(dtype) = sqrt(eps)`, an explicit value never floored or dropped, plus the float64-strictness caveat past distance ~11 (Numerical Stability).
- **Learning-rate-schedule timing** — `schedule(k−1)` on the k-th update, matching optax's `scale_by_schedule`, with bias correction deliberately on the other counter (Optimizers).

## Stale counts corrected

`20+` → `40+` layers (44 exported `nnx.Module` classes) and "3,500+ tests / 850+ test functions" → 3,551 collected items across 735 test functions, in both `README.md` and `docs/index.md`.

## Release

Version `1.0.0` → `1.1.0`, changelog `Unreleased` promoted with a summary paragraph, link refs updated, project-status line bumped.

A minor bump for a set that includes breaking entries is a deliberate maintainer call: this is internal-correctness work rather than new API surface, and every breaking entry carries its own migration line.

## Verification

- `mkdocs build --strict` — clean
- All 127 doc code blocks execute; the 5 failures above are gone and no `UserWarning`s remain
- No library code changed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)